### PR TITLE
docker: Initialized docker files workflows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM golang:1.13.5-alpine3.10 as builder
+RUN apk update && apk upgrade && \
+    apk add \
+    xz-dev \
+    musl-dev \
+    gcc
+RUN mkdir -p /go/src/github.com/mendersoftware/workflows
+COPY . /go/src/github.com/mendersoftware/workflows
+RUN cd /go/src/github.com/mendersoftware/workflows && env CGO_ENABLED=1 go build
+
+FROM alpine:3.10
+RUN apk update && apk upgrade && \
+        apk add --no-cache ca-certificates xz
+RUN mkdir -p /etc/workflows
+EXPOSE 8080
+COPY ./config.yaml /etc/workflows
+COPY ./entrypoint.sh /entrypoint.sh
+COPY --from=builder /go/src/github.com/mendersoftware/workflows/workflows /usr/bin
+CMD ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml", "server"]

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GO ?= go
 GOFMT ?= gofmt "-s"
 PACKAGES ?= $(shell $(GO) list ./...)
 GOFILES := $(shell find . -name "*.go" -type f -not -path './vendor/*')
+COMPOSECMD := docker-compose -f "docker-compose.yaml" "up" -d
 
 .PHONY: all
 all: fmt lint vet test
@@ -17,6 +18,10 @@ test:
 .PHONY: fmt
 fmt:
 	$(GOFMT) -w $(GOFILES)
+
+.PHONY: docker
+docker:
+	$(COMPOSECMD)
 
 .PHONY: lint
 lint:

--- a/README.md
+++ b/README.md
@@ -62,32 +62,32 @@ The workflows are defined as JSON files. A sample workflow follows:
 
 ```json
 {
-	"name": "decommission_device",
-	"description": "Removes device info from all services.",
-	"version": 4,
-	"tasks": [
-		{
-			"name": "delete_device_inventory",
-			"type": "HTTP",
-			"http": {
-				"uri": "http://www.mocky.io/v2/5de377e13000006800e9c9c2?mocky-delay=2000ms",
-        "method": "PUT",
-        "payload": "{\"device_id\": \"${workflow.input.device_id}\"}",
-				"headers": {
-					"X-MEN-RequestID": "${workflow.input.request_id}",
-					"Authorization": "${workflow.input.authorization}"
-				},
-				"connectionTimeOut": 1000,
-				"readTimeOut": 1000
-			}
-		}
-	],
-	"inputParameters": [
-		"device_id",
-		"request_id",
-		"authorization"
-	],
-	"schemaVersion": 1
+    "name": "decommission_device",
+    "description": "Removes device info from all services.",
+    "version": 4,
+    "tasks": [
+        {
+            "name": "delete_device_inventory",
+            "type": "http",
+            "taskdef": {
+            "uri": "http://www.mocky.io/v2/5de377e13000006800e9c9c2?mocky-delay=2000ms",
+            "method": "PUT",
+            "payload": "{\"device_id\": \"${workflow.input.device_id}\"}",
+                "headers": {
+                    "X-MEN-RequestID": "${workflow.input.request_id}",
+                    "Authorization": "${workflow.input.authorization}"
+                },
+                "connectionTimeOut": 1000,
+                "readTimeOut": 1000
+            }
+        }
+    ],
+    "inputParameters": [
+        "device_id",
+        "request_id",
+        "authorization"
+    ],
+    "schemaVersion": 1
 }
 ```
 

--- a/config.yaml
+++ b/config.yaml
@@ -8,7 +8,7 @@ listen: :8080
 # Defaults to: "mongodb://localhost"
 # Overwrite with environment variable: WORKFLOWS_MONGO_URL
 
-mongo-url: mongodb://localhost
+mongo-url: mongodb://mongo-workflows:27017
 
 # Mongodb database name
 # Defaults to: "workflows"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '2'
+version: '2.1'
 services:
   mongodb:
     image: 'bitnami/mongodb:4.0'
@@ -6,3 +6,25 @@ services:
     - "27017:27017"
     volumes:
     - ./data/mongodb:/opt/mongodb
+    networks:
+      mender:
+        aliases:
+          - mongo-workflows
+
+  workflows-worker:
+    image: 'registry.mender.io/workflows:master'
+    command: /usr/bin/workflows --config /etc/workflows/config.yml worker --automigrate
+    networks:
+      mender:
+        aliases:
+          - workflows-worker
+    
+  workflows-server:
+    image: 'registry.mender.io/workflows:master'
+    command: /usr/bin/workflows --config /etc/workflows/config.yml server --automigrate
+    networks:
+      mender:
+        aliases:
+          - workflows-server
+networks:
+    mender:

--- a/main.go
+++ b/main.go
@@ -144,7 +144,7 @@ func cmdMigrate(args *cli.Context) error {
 			3)
 	}
 	defer disconnectClient(ctx, dbClient)
-	err = doMigrations(ctx, dbClient, args.Bool("automigrate"))
+	err = doMigrations(ctx, dbClient, true)
 	if err != nil {
 		return err
 	}

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"path/filepath"
+	"strings"
 
 	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/pkg/errors"
@@ -73,6 +74,9 @@ func GetWorkflowsFromPath(path string) map[string]*Workflow {
 	}
 
 	for _, f := range files {
+		if !strings.HasSuffix(f.Name(), ".json") {
+			continue
+		}
 		fn := filepath.Join(path, f.Name())
 		if data, err := ioutil.ReadFile(fn); err == nil {
 			workflow, err := ParseWorkflowFromJSON([]byte(data))


### PR DESCRIPTION
The entrypoint.sh spawns a worker process in the background. We might
want to override the entrypoint and have the worker and server in
separate containers (mostly for sanitizing the logs).
I also updated the README.md to reflect recent changes in the api.

changelog: title

Signed-off-by: Alf-Rune Siqveland <alf.rune@northern.tech>