### PR TITLE
Refactor datastore/mock and model/taskdef and improve error handling

### DIFF
--- a/api/http/workflow.go
+++ b/api/http/workflow.go
@@ -41,6 +41,7 @@ func NewWorkflowController(dataStore store.DataStore) *WorkflowController {
 
 func (h WorkflowController) RegisterWorkflow(c *gin.Context) {
 	var workflow model.Workflow
+	ctx := context.Background()
 	rawData, err := c.GetRawData()
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
@@ -61,7 +62,7 @@ func (h WorkflowController) RegisterWorkflow(c *gin.Context) {
 		})
 		return
 	}
-	_, err = h.dataStore.InsertWorkflows(workflow)
+	_, err = h.dataStore.InsertWorkflows(ctx, workflow)
 	if err != nil {
 		c.JSON(http.StatusBadRequest, gin.H{
 			"error": err.Error(),

--- a/app/server/server.go
+++ b/app/server/server.go
@@ -39,7 +39,7 @@ func InitAndRun(conf config.Reader, dataStore store.DataStore) error {
 	if workflowsPath != "" {
 		workflows := model.GetWorkflowsFromPath(workflowsPath)
 		for _, workflow := range workflows {
-			dataStore.InsertWorkflows(*workflow)
+			dataStore.InsertWorkflows(ctx, *workflow)
 		}
 	}
 	var listen = conf.GetString(dconfig.SettingListen)

--- a/app/worker/worker.go
+++ b/app/worker/worker.go
@@ -23,10 +23,10 @@ import (
 	"os"
 	"os/signal"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
 
 	"github.com/mendersoftware/go-lib-micro/config"
 	"github.com/mendersoftware/go-lib-micro/log"
@@ -44,100 +44,96 @@ func InitAndRun(conf config.Reader, dataStore store.DataStore) error {
 	}
 	l := log.FromContext(ctx)
 
-	var job *model.Job
 	var msg interface{}
 	concurrency := conf.GetInt(dconfig.SettingConcurrency)
 	sem := make(chan bool, concurrency)
 	quit := make(chan os.Signal)
-	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(quit, unix.SIGINT, unix.SIGTERM)
 	for {
 		select {
 		case msg = <-channel:
 
 		case <-quit:
+			signal.Stop(quit)
 			l.Info("Shutdown Worker ...")
+			// Calling cancel() before returning should shut down
+			// all workers. However, the new driver is not
+			// particularly good at listening to the context in the
+			// current state, but it'll be forced to shut down
+			// eventually.
 			cancel()
-			return nil
+			return err
 		}
 		if msg == nil {
 			break
 		}
 		switch msg.(type) {
 		case *model.Job:
-			job = msg.(*model.Job)
+			job := msg.(*model.Job)
+			sem <- true
+			go func(ctx context.Context,
+				job *model.Job, dataStore store.DataStore) {
+				defer func() { <-sem }()
+				processJob(ctx, job, dataStore, sem)
+			}(ctx, job, dataStore)
 
 		case error:
+			cancel()
 			return msg.(error)
 		}
-		sem <- true
-		go func(ctx context.Context, job *model.Job, dataStore store.DataStore) {
-			defer func() { <-sem }()
-			processJob(ctx, job, dataStore)
-		}(ctx, job, dataStore)
 	}
+	cancel()
 
-	return nil
+	return err
 }
 
 func processJob(ctx context.Context, job *model.Job,
-	dataStore store.DataStore) error {
-
+	dataStore store.DataStore, sem chan bool) error {
+	sem <- true
 	l := log.FromContext(ctx)
 	workflow, err := dataStore.GetWorkflowByName(ctx, job.WorkflowName)
 	if err != nil {
 		l.Warnf("The workflow %q of job %s does not exist",
 			job.WorkflowName, job.ID)
-		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
-		if err != nil {
-			return err
-		}
+		// Mark the job as a failure
+		dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
 		return nil
 	}
 
-	job, err = dataStore.AquireJob(ctx, job)
+	aquiredJob, err := dataStore.AquireJob(ctx, job)
 	if err != nil {
 		l.Error(err.Error())
 		return err
-	} else if job == nil {
+	} else if aquiredJob == nil {
+		// Should "never" occur
 		l.Warnf("The job with given ID (%s) does not exist", job.ID)
-		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
-		if err != nil {
-			return err
-		}
 		return nil
 	}
 
+	job = aquiredJob
 	l.Infof("%s: started, %s", job.ID, job.WorkflowName)
 
 	for _, task := range workflow.Tasks {
-		switch task.Type {
-		case "http":
-			var httpTask model.HTTPTask
-			err := json.Unmarshal(task.Taskdef, &httpTask)
-			if err != nil {
-				return fmt.Errorf(
-					"Error: Task definition incompatible " +
-						"with specified type (http)")
+		results, err := processTask(task, job, workflow)
+		if err != nil {
+			if results == nil {
+				results = &model.TaskResult{}
 			}
-			results, err := processHTTPTask(&httpTask, job, workflow)
-			if err != nil {
-				dataStore.UpdateJobStatus(ctx, job,
-					model.StatusFailure)
-				return err
-			}
-			err = dataStore.UpdateJobAddResult(ctx, job, results)
-			if err != nil {
-				l.Errorf("Error uploading results: %s", err.Error())
-			}
+			results.Name = task.Name
+			results.Error = err.Error()
+		}
+		err = dataStore.UpdateJobAddResult(ctx, job, results)
+		if err != nil {
+			l.Errorf("Error uploading results: %s", err.Error())
 		}
 	}
 
 	err = dataStore.UpdateJobStatus(ctx, job, model.StatusDone)
 	if err != nil {
-		l.Warn("Unable to set job status to done")
+		l.Warnf("Unable to set job status to done: %s", err.Error())
 	}
 
-	l.Infof("%s: done", job.ID)
+	l.Infof("Job's done: %s", job.ID) // Yes mi lord!
 	return nil
 }
 
@@ -151,17 +147,55 @@ func processJobString(data string, workflow *model.Workflow, job *model.Job) str
 	return data
 }
 
-func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
+func processTask(task model.Task, job *model.Job,
 	workflow *model.Workflow) (*model.TaskResult, error) {
+
+	var result *model.TaskResult
+	var err error
+
+	switch task.Type {
+	case "http":
+		result, err = processHTTPTask(task, job, workflow)
+	default:
+		err = fmt.Errorf("Unrecognized task type: %s", task.Type)
+	}
+	if err != nil {
+		if result == nil {
+			result = &model.TaskResult{}
+		}
+		result.Name = task.Name
+	}
+	return result, err
+}
+
+// Processes a tash of type "http"
+func processHTTPTask(task model.Task, job *model.Job,
+	workflow *model.Workflow) (*model.TaskResult, error) {
+
+	var httpTask model.HTTPTask
+	results := model.HTTPResult{}
+	results.Name = task.Name
+	err := json.Unmarshal(task.Taskdef, &httpTask)
+	if err != nil {
+		results.Error = fmt.Errorf("Error: Task definition " +
+			"incompatible with specified " +
+			"type (http)").Error()
+		return results.Marshal()
+	}
+
 	uri := processJobString(httpTask.URI, workflow, job)
 	payloadString := processJobString(httpTask.Body, workflow, job)
 	payload := strings.NewReader(payloadString)
 
+	// Prepare request
 	req, err := http.NewRequest(httpTask.Method, uri, payload)
 	if err != nil {
-		return nil, err
+		results.Error = "Internal error (500)"
+		ret, _ := results.Marshal()
+		return ret, err
 	}
 
+	// Prepare resquest headers
 	var headersToBeSent []string
 	for name, value := range httpTask.Headers {
 		headerValue := processJobString(value, workflow, job)
@@ -174,24 +208,26 @@ func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
 	}
 	res, err := netClient.Do(req)
 	if err != nil {
-		return nil, err
+		results.Error = errors.Wrap(err,
+			"Internal error performing request").Error()
+		ret, _ := results.Marshal()
+		return ret, err
 	}
 
 	defer res.Body.Close()
-	resBody, _ := ioutil.ReadAll(res.Body)
-
-	result := &model.TaskResult{
-		Request: model.TaskResultRequest{
-			URI:     uri,
-			Method:  httpTask.Method,
-			Body:    payloadString,
-			Headers: headersToBeSent,
-		},
-		Response: model.TaskResultResponse{
-			StatusCode: res.StatusCode,
-			Body:       string(resBody),
-		},
+	// Build result response
+	results.Response = model.HTTPResultResponse{
+		StatusCode: res.StatusCode,
+		Headers:    (map[string][]string)(res.Header.Clone()),
 	}
 
-	return result, nil
+	resBody, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		results.Error = errors.Wrap(err,
+			"Error reading HTTP response body").Error()
+	} else {
+		results.Response.Body = string(resBody)
+	}
+	// Return generic TaskResult construct
+	return results.Marshal()
 }

--- a/main.go
+++ b/main.go
@@ -168,6 +168,5 @@ func doMigrations(ctx context.Context, client *store.MongoClient,
 func disconnectClient(parentCtx context.Context, client *store.MongoClient) {
 	ctx, cancel := context.WithTimeout(parentCtx, 10*time.Second)
 	client.Disconnect(ctx)
-	<-ctx.Done()
 	cancel()
 }

--- a/model/job.go
+++ b/model/job.go
@@ -41,6 +41,8 @@ type Job struct {
 	// WorkflowName contains the name of the workflow
 	WorkflowName string `json:"workflowName" bson:"workflow_name"`
 
+	TaskId string `json:"-" bson:"-"`
+
 	// InputParameters contains the name of the workflow
 	InputParameters []InputParameter `json:"inputParameters" bson:"input_parameters"`
 
@@ -60,26 +62,6 @@ type InputParameter struct {
 
 	// Value of the input parameter
 	Value string `json:"value" bson:"value"`
-}
-
-// TaskResult contains the result of the execution of a task
-type TaskResult struct {
-	Request  TaskResultRequest  `json:"request" bson:"request"`
-	Response TaskResultResponse `json:"response" bson:"response"`
-}
-
-// TaskResultRequest contains the request
-type TaskResultRequest struct {
-	URI     string   `json:"uri" bson:"uri"`
-	Method  string   `json:"method" bson:"method"`
-	Body    string   `json:"body" bson:"body"`
-	Headers []string `json:"headers" bson:"headers"`
-}
-
-// TaskResultResponse contains the response
-type TaskResultResponse struct {
-	StatusCode int    `json:"statusCode" bson:"status_code"`
-	Body       string `json:"body" bson:"body"`
 }
 
 // Validate job against workflow. Check that all required parameters are present.

--- a/model/taskdef.go
+++ b/model/taskdef.go
@@ -1,0 +1,83 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"encoding/json"
+)
+
+// Task stores the definition of a task within a workflow
+type Task struct {
+	// Name of the task
+	Name string `json:"name"`
+	// Type of task (determines task def structure)
+	Type string `json:"type"`
+	// Definition of the task
+	Taskdef json.RawMessage `json:"taskdef" bson:"taskdef"`
+}
+
+type Result interface {
+	// Marshal converts a specific type of results to a generic one
+	Marshal() (*TaskResult, error)
+}
+
+// Generic TaskResult type
+type TaskResult struct {
+	// Name of the completed task (necessary if execution is out of order)
+	Name string `json:"name" bson:"name"`
+	// Raw json of underlying results - may vary depending on type.
+	Result []byte `json:"result" bson:"result"`
+	// Error message if any errors occured during execution
+	Error string `json:"error,omitempty" bson:"error"`
+}
+
+func (t *TaskResult) Marshal() (*TaskResult, error) {
+	return t, nil
+}
+
+// HTTPTask stores the parameters of the HTTP calls for a WorkflowTask
+type HTTPTask struct {
+	URI               string            `json:"uri"`
+	Method            string            `json:"method"`
+	Headers           map[string]string `json:"headers"`
+	Body              string            `json:"body,omitempty"`
+	ConnectionTimeOut int               `json:"connectionTimeOut,omitempty"`
+	ReadTimeOut       int               `json:"readTimeOut,omitempty"`
+}
+
+// TaskResult contains the result of the execution of a task
+type HTTPResult struct {
+	Name     string             `json:"name" bson:"name"`
+	Response HTTPResultResponse `json:"response" bson:"response"`
+	Error    string             `json:"-"`
+}
+
+// TaskResultResponse contains the response
+type HTTPResultResponse struct {
+	StatusCode int                 `json:"statusCode" bson:"status_code"`
+	Headers    map[string][]string `json:"headers" bson:"headers"`
+	Body       string              `json:"body" bson:"body"`
+}
+
+func (t *HTTPResult) Marshal() (*TaskResult, error) {
+	var ret TaskResult
+	buf, err := json.Marshal(t)
+	if err != nil {
+		return nil, err
+	}
+	ret.Result = buf
+	ret.Error = t.Error
+	return &ret, nil
+}

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -34,27 +34,6 @@ type Workflow struct {
 	InputParameters []string `json:"inputParameters" bson:"input_parameters"`
 }
 
-// Task stores the definition of a task within a workflow
-type Task struct {
-	// Name of the task
-	Name string `json:"name"`
-	// Type of task (determines task def structure)
-	Type string `json:"type"`
-	// Definition of the task
-	Taskdef json.RawMessage `json:"taskdef" bson:"taskdef"`
-}
-
-// HTTPTask stores the parameters of the HTTP calls for a WorkflowTask
-type HTTPTask struct {
-	URI               string            `json:"uri"`
-	Method            string            `json:"method"`
-	ContentType       string            `json:"contentType,omitempty"`
-	Body              string            `json:"body,omitempty"`
-	Headers           map[string]string `json:"headers"`
-	ConnectionTimeOut int               `json:"connectionTimeOut"`
-	ReadTimeOut       int               `json:"readTimeOut"`
-}
-
 // ParseWorkflowFromJSON parse a JSON string and returns a Workflow struct
 func ParseWorkflowFromJSON(jsonData []byte) (*Workflow, error) {
 	var workflow Workflow

--- a/store/datastore.go
+++ b/store/datastore.go
@@ -15,14 +15,13 @@ var (
 
 // DataStoreMongoInterface for DataStore  services
 type DataStore interface {
-	InsertWorkflows(workflow ...model.Workflow) (int, error)
-	GetWorkflowByName(workflowName string) (*model.Workflow, error)
+	InsertWorkflows(ctx context.Context, workflow ...model.Workflow) (int, error)
+	GetWorkflowByName(ctx context.Context, workflowName string) (*model.Workflow, error)
 	GetWorkflows() []model.Workflow
 	InsertJob(ctx context.Context, job *model.Job) (*model.Job, error)
-	GetJobs(ctx context.Context) <-chan *model.Job
+	GetJobs(ctx context.Context) (<-chan interface{}, error)
 	AquireJob(ctx context.Context, job *model.Job) (*model.Job, error)
 	UpdateJobAddResult(ctx context.Context, job *model.Job, result *model.TaskResult) error
 	UpdateJobStatus(ctx context.Context, job *model.Job, status int) error
 	GetJobByNameAndID(ctx context.Context, name string, ID string) (*model.Job, error)
-	Shutdown()
 }

--- a/store/mock/datastore_mock.go
+++ b/store/mock/datastore_mock.go
@@ -17,96 +17,211 @@ package mock
 import (
 	"context"
 
-	"go.mongodb.org/mongo-driver/bson/primitive"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/mendersoftware/workflows/model"
-	"github.com/mendersoftware/workflows/store"
 )
 
-// DataStoreMock is a mocked data storage service
-type DataStoreMock struct {
-	// Jobs contains the list of queued jobs
-	Jobs      []model.Job
-	Workflows map[string]*model.Workflow
-	channel   chan *model.Job
+type DataStore struct {
+	mock.Mock
 }
 
-// NewDataStoreMock initializes a DataStore mock object
-func NewDataStoreMock() *DataStoreMock {
+// NewDataStore initializes a DataStore mock object
+func NewDataStore() *DataStore {
 
-	return &DataStoreMock{
-		channel:   make(chan *model.Job),
-		Workflows: make(map[string]*model.Workflow),
+	return &DataStore{}
+}
+
+func (db *DataStore) InsertWorkflows(ctx context.Context,
+	workflows ...model.Workflow) (int, error) {
+	ret := db.Called(ctx, workflows)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(context.Context, []model.Workflow) int); ok {
+		r0 = rf(ctx, workflows)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(int)
+		}
 	}
-}
 
-func (db *DataStoreMock) InsertWorkflows(workflows ...model.Workflow) (int, error) {
-	for _, workflow := range workflows {
-		db.Workflows[workflow.Name] = &workflow
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, []model.Workflow) error); ok {
+		r1 = rf(ctx, workflows)
+	} else {
+		r1 = ret.Error(1)
 	}
-	return len(workflows), nil
+	return r0, r1
 }
 
-func (db *DataStoreMock) GetWorkflowByName(
+func (db *DataStore) GetWorkflowByName(ctx context.Context,
 	workflowName string) (*model.Workflow, error) {
-	return db.Workflows[workflowName], nil
+	ret := db.Called(workflowName)
+
+	var r0 *model.Workflow
+	if rf, ok := ret.
+		Get(0).(func(context.Context, string) *model.Workflow); ok {
+		r0 = rf(ctx, workflowName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Workflow)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, workflowName)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
 }
 
-func (db *DataStoreMock) GetWorkflows() []model.Workflow {
-	workflows := make([]model.Workflow, len(db.Workflows))
-	i := 0
-	for _, workflow := range db.Workflows {
-		workflows[i] = *workflow
-		i++
+func (db *DataStore) GetWorkflows() []model.Workflow {
+	ret := db.Called()
+
+	var r0 []model.Workflow
+	if rf, ok := ret.Get(0).(func() []model.Workflow); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]model.Workflow)
+		}
 	}
-	return workflows
+
+	return r0
 }
 
 // InsertJob inserts the job in the queue
-func (db *DataStoreMock) InsertJob(ctx context.Context, job *model.Job) (*model.Job, error) {
-	job.ID = primitive.NewObjectID().Hex()
-	if wf, ok := db.Workflows[job.WorkflowName]; ok {
-		if err := job.Validate(wf); err != nil {
-			return nil, err
-		}
-	} else {
-		return nil, store.ErrWorkflowNotFound
-	}
-	db.Jobs = append(db.Jobs, *job)
+func (db *DataStore) InsertJob(ctx context.Context, job *model.Job) (*model.Job, error) {
+	ret := db.Called(ctx, job)
 
-	return job, nil
+	var r0 *model.Job
+	if rf, ok := ret.
+		Get(0).(func(context.Context, *model.Job) *model.Job); ok {
+		r0 = rf(ctx, job)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Job)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, *model.Job) error); ok {
+		r1 = rf(ctx, job)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // GetJobs returns a channel of Jobs
-func (db *DataStoreMock) GetJobs(ctx context.Context) <-chan *model.Job {
-	return db.channel
+func (db *DataStore) GetJobs(ctx context.Context) (<-chan interface{}, error) {
+	ret := db.Called(ctx)
+	var r0 <-chan interface{}
+	if rf, ok := ret.Get(0).(func(context.Context) <-chan interface{}); ok {
+		r0 = rf(ctx)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(<-chan interface{})
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
+		r1 = rf(ctx)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // AquireJob gets given job and updates it's status to StatusProcessing.
-func (db *DataStoreMock) AquireJob(ctx context.Context,
+func (db *DataStore) AquireJob(ctx context.Context,
 	job *model.Job) (*model.Job, error) {
-	return nil, nil
+	ret := db.Called(ctx, job)
+
+	var r0 *model.Job
+	if rf, ok := ret.Get(0).(func(
+		context.Context, *model.Job) *model.Job); ok {
+		r0 = rf(ctx, job)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Job)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, *model.Job) error); ok {
+		r1 = rf(ctx, job)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // UpdateJobAddResult add a task execution result to a job status
-func (db *DataStoreMock) UpdateJobAddResult(ctx context.Context,
+func (db *DataStore) UpdateJobAddResult(ctx context.Context,
 	job *model.Job, result *model.TaskResult) error {
-	return nil
+	ret := db.Called(ctx, job, result)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(
+		context.Context, *model.Job, *model.TaskResult) error); ok {
+		r0 = rf(ctx, job, result)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // UpdateJobStatus set the task execution status for a job status
-func (db *DataStoreMock) UpdateJobStatus(ctx context.Context, job *model.Job,
+func (db *DataStore) UpdateJobStatus(ctx context.Context, job *model.Job,
 	status int) error {
-	return nil
+	ret := db.Called(ctx, job, status)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(
+		context.Context, *model.Job, int) error); ok {
+		r0 = rf(ctx, job, status)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // GetJobStatusByNameAndID get the task execution status for a job status bu Name and ID
-func (db *DataStoreMock) GetJobByNameAndID(ctx context.Context,
-	name string, ID string) (*model.Job, error) {
-	return nil, nil
+func (db *DataStore) GetJobByNameAndID(ctx context.Context,
+	name, ID string) (*model.Job, error) {
+	ret := db.Called(ctx, name, ID)
+
+	var r0 *model.Job
+	if rf, ok := ret.Get(0).(func(
+		context.Context, string, string) *model.Job); ok {
+		r0 = rf(ctx, name, ID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Job)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(
+		context.Context, string, string) error); ok {
+		r1 = rf(ctx, name, ID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Shutdown shuts down the datastore GetJobs process
-func (db *DataStoreMock) Shutdown() {
-
+func (db *DataStore) Shutdown() {
+	db.Called()
 }

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -372,15 +372,16 @@ func (db *DataStoreMongo) UpdateJobStatus(
 	if model.StatusToString(status) == "unknown" {
 		return model.ErrInvalidStatus
 	}
+	query := bson.M{
+		"_id":    job.ID,
+		"status": bson.M{"$ne": model.StatusFailure},
+	}
+	update := bson.D{
+		{Key: "$set", Value: bson.M{"status": status}},
+	}
 	collection := db.client.Database(db.dbName).
 		Collection(JobsCollectionName)
-	_, err := collection.UpdateOne(ctx, bson.M{
-		"_id": job.ID,
-	}, bson.M{
-		"$set": bson.M{
-			"status": status,
-		},
-	})
+	_, err := collection.UpdateOne(ctx, query, update)
 	if err != nil {
 		return err
 	}

--- a/vendor/github.com/stretchr/objx/LICENSE
+++ b/vendor/github.com/stretchr/objx/LICENSE
@@ -1,0 +1,22 @@
+The MIT License
+
+Copyright (c) 2014 Stretchr, Inc.
+Copyright (c) 2017-2018 objx contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/vendor/github.com/stretchr/objx/README.md
+++ b/vendor/github.com/stretchr/objx/README.md
@@ -1,0 +1,80 @@
+# Objx
+[![Build Status](https://travis-ci.org/stretchr/objx.svg?branch=master)](https://travis-ci.org/stretchr/objx)
+[![Go Report Card](https://goreportcard.com/badge/github.com/stretchr/objx)](https://goreportcard.com/report/github.com/stretchr/objx)
+[![Maintainability](https://api.codeclimate.com/v1/badges/1d64bc6c8474c2074f2b/maintainability)](https://codeclimate.com/github/stretchr/objx/maintainability)
+[![Test Coverage](https://api.codeclimate.com/v1/badges/1d64bc6c8474c2074f2b/test_coverage)](https://codeclimate.com/github/stretchr/objx/test_coverage)
+[![Sourcegraph](https://sourcegraph.com/github.com/stretchr/objx/-/badge.svg)](https://sourcegraph.com/github.com/stretchr/objx)
+[![GoDoc](https://godoc.org/github.com/stretchr/objx?status.svg)](https://godoc.org/github.com/stretchr/objx)
+
+Objx - Go package for dealing with maps, slices, JSON and other data.
+
+Get started:
+
+- Install Objx with [one line of code](#installation), or [update it with another](#staying-up-to-date)
+- Check out the API Documentation http://godoc.org/github.com/stretchr/objx
+
+## Overview
+Objx provides the `objx.Map` type, which is a `map[string]interface{}` that exposes a powerful `Get` method (among others) that allows you to easily and quickly get access to data within the map, without having to worry too much about type assertions, missing data, default values etc.
+
+### Pattern
+Objx uses a preditable pattern to make access data from within `map[string]interface{}` easy. Call one of the `objx.` functions to create your `objx.Map` to get going:
+
+    m, err := objx.FromJSON(json)
+
+NOTE: Any methods or functions with the `Must` prefix will panic if something goes wrong, the rest will be optimistic and try to figure things out without panicking.
+
+Use `Get` to access the value you're interested in.  You can use dot and array
+notation too:
+
+     m.Get("places[0].latlng")
+
+Once you have sought the `Value` you're interested in, you can use the `Is*` methods to determine its type.
+
+     if m.Get("code").IsStr() { // Your code... }
+
+Or you can just assume the type, and use one of the strong type methods to extract the real value:
+
+    m.Get("code").Int()
+
+If there's no value there (or if it's the wrong type) then a default value will be returned, or you can be explicit about the default value.
+
+     Get("code").Int(-1)
+
+If you're dealing with a slice of data as a value, Objx provides many useful methods for iterating, manipulating and selecting that data.  You can find out more by exploring the index below.
+
+### Reading data
+A simple example of how to use Objx:
+
+    // Use MustFromJSON to make an objx.Map from some JSON
+    m := objx.MustFromJSON(`{"name": "Mat", "age": 30}`)
+
+    // Get the details
+    name := m.Get("name").Str()
+    age := m.Get("age").Int()
+
+    // Get their nickname (or use their name if they don't have one)
+    nickname := m.Get("nickname").Str(name)
+
+### Ranging
+Since `objx.Map` is a `map[string]interface{}` you can treat it as such.  For example, to `range` the data, do what you would expect:
+
+    m := objx.MustFromJSON(json)
+    for key, value := range m {
+      // Your code...
+    }
+
+## Installation
+To install Objx, use go get:
+
+    go get github.com/stretchr/objx
+
+### Staying up to date
+To update Objx to the latest version, run:
+
+    go get -u github.com/stretchr/objx
+
+### Supported go versions
+We support the lastest three major Go versions, which are 1.10, 1.11 and 1.12 at the moment.
+
+## Contributing
+Please feel free to submit issues, fork the repository and send pull requests!

--- a/vendor/github.com/stretchr/objx/Taskfile.yml
+++ b/vendor/github.com/stretchr/objx/Taskfile.yml
@@ -1,0 +1,30 @@
+version: '2'
+
+env:
+  GOFLAGS: -mod=vendor
+
+tasks:
+  default:
+    deps: [test]
+
+  lint:
+    desc: Checks code style
+    cmds:
+      - gofmt -d -s *.go
+      - go vet ./...
+    silent: true
+
+  lint-fix:
+    desc: Fixes code style
+    cmds:
+      - gofmt -w -s *.go
+
+  test:
+    desc: Runs go tests
+    cmds:
+      - go test -race  ./...
+
+  test-coverage:
+    desc: Runs go tests and calucates test coverage
+    cmds:
+      - go test -race -coverprofile=c.out ./...

--- a/vendor/github.com/stretchr/objx/accessors.go
+++ b/vendor/github.com/stretchr/objx/accessors.go
@@ -1,0 +1,179 @@
+package objx
+
+import (
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+const (
+	// PathSeparator is the character used to separate the elements
+	// of the keypath.
+	//
+	// For example, `location.address.city`
+	PathSeparator string = "."
+
+	// arrayAccesRegexString is the regex used to extract the array number
+	// from the access path
+	arrayAccesRegexString = `^(.+)\[([0-9]+)\]$`
+
+	// mapAccessRegexString is the regex used to extract the map key
+	// from the access path
+	mapAccessRegexString = `^([^\[]*)\[([^\]]+)\](.*)$`
+)
+
+// arrayAccesRegex is the compiled arrayAccesRegexString
+var arrayAccesRegex = regexp.MustCompile(arrayAccesRegexString)
+
+// mapAccessRegex is the compiled mapAccessRegexString
+var mapAccessRegex = regexp.MustCompile(mapAccessRegexString)
+
+// Get gets the value using the specified selector and
+// returns it inside a new Obj object.
+//
+// If it cannot find the value, Get will return a nil
+// value inside an instance of Obj.
+//
+// Get can only operate directly on map[string]interface{} and []interface.
+//
+// Example
+//
+// To access the title of the third chapter of the second book, do:
+//
+//    o.Get("books[1].chapters[2].title")
+func (m Map) Get(selector string) *Value {
+	rawObj := access(m, selector, nil, false)
+	return &Value{data: rawObj}
+}
+
+// Set sets the value using the specified selector and
+// returns the object on which Set was called.
+//
+// Set can only operate directly on map[string]interface{} and []interface
+//
+// Example
+//
+// To set the title of the third chapter of the second book, do:
+//
+//    o.Set("books[1].chapters[2].title","Time to Go")
+func (m Map) Set(selector string, value interface{}) Map {
+	access(m, selector, value, true)
+	return m
+}
+
+// getIndex returns the index, which is hold in s by two braches.
+// It also returns s withour the index part, e.g. name[1] will return (1, name).
+// If no index is found, -1 is returned
+func getIndex(s string) (int, string) {
+	arrayMatches := arrayAccesRegex.FindStringSubmatch(s)
+	if len(arrayMatches) > 0 {
+		// Get the key into the map
+		selector := arrayMatches[1]
+		// Get the index into the array at the key
+		// We know this cannt fail because arrayMatches[2] is an int for sure
+		index, _ := strconv.Atoi(arrayMatches[2])
+		return index, selector
+	}
+	return -1, s
+}
+
+// getKey returns the key which is held in s by two brackets.
+// It also returns the next selector.
+func getKey(s string) (string, string) {
+	selSegs := strings.SplitN(s, PathSeparator, 2)
+	thisSel := selSegs[0]
+	nextSel := ""
+
+	if len(selSegs) > 1 {
+		nextSel = selSegs[1]
+	}
+
+	mapMatches := mapAccessRegex.FindStringSubmatch(s)
+	if len(mapMatches) > 0 {
+		if _, err := strconv.Atoi(mapMatches[2]); err != nil {
+			thisSel = mapMatches[1]
+			nextSel = "[" + mapMatches[2] + "]" + mapMatches[3]
+
+			if thisSel == "" {
+				thisSel = mapMatches[2]
+				nextSel = mapMatches[3]
+			}
+
+			if nextSel == "" {
+				selSegs = []string{"", ""}
+			} else if nextSel[0] == '.' {
+				nextSel = nextSel[1:]
+			}
+		}
+	}
+
+	return thisSel, nextSel
+}
+
+// access accesses the object using the selector and performs the
+// appropriate action.
+func access(current interface{}, selector string, value interface{}, isSet bool) interface{} {
+	thisSel, nextSel := getKey(selector)
+
+	index := -1
+	if strings.Contains(thisSel, "[") {
+		index, thisSel = getIndex(thisSel)
+	}
+
+	if curMap, ok := current.(Map); ok {
+		current = map[string]interface{}(curMap)
+	}
+	// get the object in question
+	switch current.(type) {
+	case map[string]interface{}:
+		curMSI := current.(map[string]interface{})
+		if nextSel == "" && isSet {
+			curMSI[thisSel] = value
+			return nil
+		}
+
+		_, ok := curMSI[thisSel].(map[string]interface{})
+		if (curMSI[thisSel] == nil || !ok) && index == -1 && isSet {
+			curMSI[thisSel] = map[string]interface{}{}
+		}
+
+		current = curMSI[thisSel]
+	default:
+		current = nil
+	}
+
+	// do we need to access the item of an array?
+	if index > -1 {
+		if array, ok := interSlice(current); ok {
+			if index < len(array) {
+				current = array[index]
+			} else {
+				current = nil
+			}
+		}
+	}
+	if nextSel != "" {
+		current = access(current, nextSel, value, isSet)
+	}
+	return current
+}
+
+func interSlice(slice interface{}) ([]interface{}, bool) {
+	if array, ok := slice.([]interface{}); ok {
+		return array, ok
+	}
+
+	s := reflect.ValueOf(slice)
+	if s.Kind() != reflect.Slice {
+		return nil, false
+	}
+
+	ret := make([]interface{}, s.Len())
+
+	for i := 0; i < s.Len(); i++ {
+		ret[i] = s.Index(i).Interface()
+	}
+
+	return ret, true
+}

--- a/vendor/github.com/stretchr/objx/conversions.go
+++ b/vendor/github.com/stretchr/objx/conversions.go
@@ -1,0 +1,280 @@
+package objx
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"strconv"
+)
+
+// SignatureSeparator is the character that is used to
+// separate the Base64 string from the security signature.
+const SignatureSeparator = "_"
+
+// URLValuesSliceKeySuffix is the character that is used to
+// specify a suffic for slices parsed by URLValues.
+// If the suffix is set to "[i]", then the index of the slice
+// is used in place of i
+// Ex: Suffix "[]" would have the form a[]=b&a[]=c
+// OR Suffix "[i]" would have the form a[0]=b&a[1]=c
+// OR Suffix "" would have the form a=b&a=c
+var urlValuesSliceKeySuffix = "[]"
+
+const (
+	URLValuesSliceKeySuffixEmpty = ""
+	URLValuesSliceKeySuffixArray = "[]"
+	URLValuesSliceKeySuffixIndex = "[i]"
+)
+
+// SetURLValuesSliceKeySuffix sets the character that is used to
+// specify a suffic for slices parsed by URLValues.
+// If the suffix is set to "[i]", then the index of the slice
+// is used in place of i
+// Ex: Suffix "[]" would have the form a[]=b&a[]=c
+// OR Suffix "[i]" would have the form a[0]=b&a[1]=c
+// OR Suffix "" would have the form a=b&a=c
+func SetURLValuesSliceKeySuffix(s string) error {
+	if s == URLValuesSliceKeySuffixEmpty || s == URLValuesSliceKeySuffixArray || s == URLValuesSliceKeySuffixIndex {
+		urlValuesSliceKeySuffix = s
+		return nil
+	}
+
+	return errors.New("objx: Invalid URLValuesSliceKeySuffix provided.")
+}
+
+// JSON converts the contained object to a JSON string
+// representation
+func (m Map) JSON() (string, error) {
+	for k, v := range m {
+		m[k] = cleanUp(v)
+	}
+
+	result, err := json.Marshal(m)
+	if err != nil {
+		err = errors.New("objx: JSON encode failed with: " + err.Error())
+	}
+	return string(result), err
+}
+
+func cleanUpInterfaceArray(in []interface{}) []interface{} {
+	result := make([]interface{}, len(in))
+	for i, v := range in {
+		result[i] = cleanUp(v)
+	}
+	return result
+}
+
+func cleanUpInterfaceMap(in map[interface{}]interface{}) Map {
+	result := Map{}
+	for k, v := range in {
+		result[fmt.Sprintf("%v", k)] = cleanUp(v)
+	}
+	return result
+}
+
+func cleanUpStringMap(in map[string]interface{}) Map {
+	result := Map{}
+	for k, v := range in {
+		result[k] = cleanUp(v)
+	}
+	return result
+}
+
+func cleanUpMSIArray(in []map[string]interface{}) []Map {
+	result := make([]Map, len(in))
+	for i, v := range in {
+		result[i] = cleanUpStringMap(v)
+	}
+	return result
+}
+
+func cleanUpMapArray(in []Map) []Map {
+	result := make([]Map, len(in))
+	for i, v := range in {
+		result[i] = cleanUpStringMap(v)
+	}
+	return result
+}
+
+func cleanUp(v interface{}) interface{} {
+	switch v := v.(type) {
+	case []interface{}:
+		return cleanUpInterfaceArray(v)
+	case []map[string]interface{}:
+		return cleanUpMSIArray(v)
+	case map[interface{}]interface{}:
+		return cleanUpInterfaceMap(v)
+	case Map:
+		return cleanUpStringMap(v)
+	case []Map:
+		return cleanUpMapArray(v)
+	default:
+		return v
+	}
+}
+
+// MustJSON converts the contained object to a JSON string
+// representation and panics if there is an error
+func (m Map) MustJSON() string {
+	result, err := m.JSON()
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+// Base64 converts the contained object to a Base64 string
+// representation of the JSON string representation
+func (m Map) Base64() (string, error) {
+	var buf bytes.Buffer
+
+	jsonData, err := m.JSON()
+	if err != nil {
+		return "", err
+	}
+
+	encoder := base64.NewEncoder(base64.StdEncoding, &buf)
+	_, _ = encoder.Write([]byte(jsonData))
+	_ = encoder.Close()
+
+	return buf.String(), nil
+}
+
+// MustBase64 converts the contained object to a Base64 string
+// representation of the JSON string representation and panics
+// if there is an error
+func (m Map) MustBase64() string {
+	result, err := m.Base64()
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+// SignedBase64 converts the contained object to a Base64 string
+// representation of the JSON string representation and signs it
+// using the provided key.
+func (m Map) SignedBase64(key string) (string, error) {
+	base64, err := m.Base64()
+	if err != nil {
+		return "", err
+	}
+
+	sig := HashWithKey(base64, key)
+	return base64 + SignatureSeparator + sig, nil
+}
+
+// MustSignedBase64 converts the contained object to a Base64 string
+// representation of the JSON string representation and signs it
+// using the provided key and panics if there is an error
+func (m Map) MustSignedBase64(key string) string {
+	result, err := m.SignedBase64(key)
+	if err != nil {
+		panic(err.Error())
+	}
+	return result
+}
+
+/*
+	URL Query
+	------------------------------------------------
+*/
+
+// URLValues creates a url.Values object from an Obj. This
+// function requires that the wrapped object be a map[string]interface{}
+func (m Map) URLValues() url.Values {
+	vals := make(url.Values)
+
+	m.parseURLValues(m, vals, "")
+
+	return vals
+}
+
+func (m Map) parseURLValues(queryMap Map, vals url.Values, key string) {
+	useSliceIndex := false
+	if urlValuesSliceKeySuffix == "[i]" {
+		useSliceIndex = true
+	}
+
+	for k, v := range queryMap {
+		val := &Value{data: v}
+		switch {
+		case val.IsObjxMap():
+			if key == "" {
+				m.parseURLValues(val.ObjxMap(), vals, k)
+			} else {
+				m.parseURLValues(val.ObjxMap(), vals, key+"["+k+"]")
+			}
+		case val.IsObjxMapSlice():
+			sliceKey := k
+			if key != "" {
+				sliceKey = key + "[" + k + "]"
+			}
+
+			if useSliceIndex {
+				for i, sv := range val.MustObjxMapSlice() {
+					sk := sliceKey + "[" + strconv.FormatInt(int64(i), 10) + "]"
+					m.parseURLValues(sv, vals, sk)
+				}
+			} else {
+				sliceKey = sliceKey + urlValuesSliceKeySuffix
+				for _, sv := range val.MustObjxMapSlice() {
+					m.parseURLValues(sv, vals, sliceKey)
+				}
+			}
+		case val.IsMSISlice():
+			sliceKey := k
+			if key != "" {
+				sliceKey = key + "[" + k + "]"
+			}
+
+			if useSliceIndex {
+				for i, sv := range val.MustMSISlice() {
+					sk := sliceKey + "[" + strconv.FormatInt(int64(i), 10) + "]"
+					m.parseURLValues(New(sv), vals, sk)
+				}
+			} else {
+				sliceKey = sliceKey + urlValuesSliceKeySuffix
+				for _, sv := range val.MustMSISlice() {
+					m.parseURLValues(New(sv), vals, sliceKey)
+				}
+			}
+		case val.IsStrSlice(), val.IsBoolSlice(),
+			val.IsFloat32Slice(), val.IsFloat64Slice(),
+			val.IsIntSlice(), val.IsInt8Slice(), val.IsInt16Slice(), val.IsInt32Slice(), val.IsInt64Slice(),
+			val.IsUintSlice(), val.IsUint8Slice(), val.IsUint16Slice(), val.IsUint32Slice(), val.IsUint64Slice():
+
+			sliceKey := k
+			if key != "" {
+				sliceKey = key + "[" + k + "]"
+			}
+
+			if useSliceIndex {
+				for i, sv := range val.StringSlice() {
+					sk := sliceKey + "[" + strconv.FormatInt(int64(i), 10) + "]"
+					vals.Set(sk, sv)
+				}
+			} else {
+				sliceKey = sliceKey + urlValuesSliceKeySuffix
+				vals[sliceKey] = val.StringSlice()
+			}
+
+		default:
+			if key == "" {
+				vals.Set(k, val.String())
+			} else {
+				vals.Set(key+"["+k+"]", val.String())
+			}
+		}
+	}
+}
+
+// URLQuery gets an encoded URL query representing the given
+// Obj. This function requires that the wrapped object be a
+// map[string]interface{}
+func (m Map) URLQuery() (string, error) {
+	return m.URLValues().Encode(), nil
+}

--- a/vendor/github.com/stretchr/objx/doc.go
+++ b/vendor/github.com/stretchr/objx/doc.go
@@ -1,0 +1,66 @@
+/*
+Objx - Go package for dealing with maps, slices, JSON and other data.
+
+Overview
+
+Objx provides the `objx.Map` type, which is a `map[string]interface{}` that exposes
+a powerful `Get` method (among others) that allows you to easily and quickly get
+access to data within the map, without having to worry too much about type assertions,
+missing data, default values etc.
+
+Pattern
+
+Objx uses a preditable pattern to make access data from within `map[string]interface{}` easy.
+Call one of the `objx.` functions to create your `objx.Map` to get going:
+
+    m, err := objx.FromJSON(json)
+
+NOTE: Any methods or functions with the `Must` prefix will panic if something goes wrong,
+the rest will be optimistic and try to figure things out without panicking.
+
+Use `Get` to access the value you're interested in.  You can use dot and array
+notation too:
+
+     m.Get("places[0].latlng")
+
+Once you have sought the `Value` you're interested in, you can use the `Is*` methods to determine its type.
+
+     if m.Get("code").IsStr() { // Your code... }
+
+Or you can just assume the type, and use one of the strong type methods to extract the real value:
+
+   m.Get("code").Int()
+
+If there's no value there (or if it's the wrong type) then a default value will be returned,
+or you can be explicit about the default value.
+
+     Get("code").Int(-1)
+
+If you're dealing with a slice of data as a value, Objx provides many useful methods for iterating,
+manipulating and selecting that data.  You can find out more by exploring the index below.
+
+Reading data
+
+A simple example of how to use Objx:
+
+   // Use MustFromJSON to make an objx.Map from some JSON
+   m := objx.MustFromJSON(`{"name": "Mat", "age": 30}`)
+
+   // Get the details
+   name := m.Get("name").Str()
+   age := m.Get("age").Int()
+
+   // Get their nickname (or use their name if they don't have one)
+   nickname := m.Get("nickname").Str(name)
+
+Ranging
+
+Since `objx.Map` is a `map[string]interface{}` you can treat it as such.
+For example, to `range` the data, do what you would expect:
+
+    m := objx.MustFromJSON(json)
+    for key, value := range m {
+      // Your code...
+    }
+*/
+package objx

--- a/vendor/github.com/stretchr/objx/go.mod
+++ b/vendor/github.com/stretchr/objx/go.mod
@@ -1,0 +1,8 @@
+module github.com/stretchr/objx
+
+go 1.12
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.3.0
+)

--- a/vendor/github.com/stretchr/objx/go.sum
+++ b/vendor/github.com/stretchr/objx/go.sum
@@ -1,0 +1,8 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/vendor/github.com/stretchr/objx/map.go
+++ b/vendor/github.com/stretchr/objx/map.go
@@ -1,0 +1,228 @@
+package objx
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"io/ioutil"
+	"net/url"
+	"strings"
+)
+
+// MSIConvertable is an interface that defines methods for converting your
+// custom types to a map[string]interface{} representation.
+type MSIConvertable interface {
+	// MSI gets a map[string]interface{} (msi) representing the
+	// object.
+	MSI() map[string]interface{}
+}
+
+// Map provides extended functionality for working with
+// untyped data, in particular map[string]interface (msi).
+type Map map[string]interface{}
+
+// Value returns the internal value instance
+func (m Map) Value() *Value {
+	return &Value{data: m}
+}
+
+// Nil represents a nil Map.
+var Nil = New(nil)
+
+// New creates a new Map containing the map[string]interface{} in the data argument.
+// If the data argument is not a map[string]interface, New attempts to call the
+// MSI() method on the MSIConvertable interface to create one.
+func New(data interface{}) Map {
+	if _, ok := data.(map[string]interface{}); !ok {
+		if converter, ok := data.(MSIConvertable); ok {
+			data = converter.MSI()
+		} else {
+			return nil
+		}
+	}
+	return Map(data.(map[string]interface{}))
+}
+
+// MSI creates a map[string]interface{} and puts it inside a new Map.
+//
+// The arguments follow a key, value pattern.
+//
+//
+// Returns nil if any key argument is non-string or if there are an odd number of arguments.
+//
+// Example
+//
+// To easily create Maps:
+//
+//     m := objx.MSI("name", "Mat", "age", 29, "subobj", objx.MSI("active", true))
+//
+//     // creates an Map equivalent to
+//     m := objx.Map{"name": "Mat", "age": 29, "subobj": objx.Map{"active": true}}
+func MSI(keyAndValuePairs ...interface{}) Map {
+	newMap := Map{}
+	keyAndValuePairsLen := len(keyAndValuePairs)
+	if keyAndValuePairsLen%2 != 0 {
+		return nil
+	}
+	for i := 0; i < keyAndValuePairsLen; i = i + 2 {
+		key := keyAndValuePairs[i]
+		value := keyAndValuePairs[i+1]
+
+		// make sure the key is a string
+		keyString, keyStringOK := key.(string)
+		if !keyStringOK {
+			return nil
+		}
+		newMap[keyString] = value
+	}
+	return newMap
+}
+
+// ****** Conversion Constructors
+
+// MustFromJSON creates a new Map containing the data specified in the
+// jsonString.
+//
+// Panics if the JSON is invalid.
+func MustFromJSON(jsonString string) Map {
+	o, err := FromJSON(jsonString)
+	if err != nil {
+		panic("objx: MustFromJSON failed with error: " + err.Error())
+	}
+	return o
+}
+
+// FromJSON creates a new Map containing the data specified in the
+// jsonString.
+//
+// Returns an error if the JSON is invalid.
+func FromJSON(jsonString string) (Map, error) {
+	var m Map
+	err := json.Unmarshal([]byte(jsonString), &m)
+	if err != nil {
+		return Nil, err
+	}
+	m.tryConvertFloat64()
+	return m, nil
+}
+
+func (m Map) tryConvertFloat64() {
+	for k, v := range m {
+		switch v.(type) {
+		case float64:
+			f := v.(float64)
+			if float64(int(f)) == f {
+				m[k] = int(f)
+			}
+		case map[string]interface{}:
+			t := New(v)
+			t.tryConvertFloat64()
+			m[k] = t
+		case []interface{}:
+			m[k] = tryConvertFloat64InSlice(v.([]interface{}))
+		}
+	}
+}
+
+func tryConvertFloat64InSlice(s []interface{}) []interface{} {
+	for k, v := range s {
+		switch v.(type) {
+		case float64:
+			f := v.(float64)
+			if float64(int(f)) == f {
+				s[k] = int(f)
+			}
+		case map[string]interface{}:
+			t := New(v)
+			t.tryConvertFloat64()
+			s[k] = t
+		case []interface{}:
+			s[k] = tryConvertFloat64InSlice(v.([]interface{}))
+		}
+	}
+	return s
+}
+
+// FromBase64 creates a new Obj containing the data specified
+// in the Base64 string.
+//
+// The string is an encoded JSON string returned by Base64
+func FromBase64(base64String string) (Map, error) {
+	decoder := base64.NewDecoder(base64.StdEncoding, strings.NewReader(base64String))
+	decoded, err := ioutil.ReadAll(decoder)
+	if err != nil {
+		return nil, err
+	}
+	return FromJSON(string(decoded))
+}
+
+// MustFromBase64 creates a new Obj containing the data specified
+// in the Base64 string and panics if there is an error.
+//
+// The string is an encoded JSON string returned by Base64
+func MustFromBase64(base64String string) Map {
+	result, err := FromBase64(base64String)
+	if err != nil {
+		panic("objx: MustFromBase64 failed with error: " + err.Error())
+	}
+	return result
+}
+
+// FromSignedBase64 creates a new Obj containing the data specified
+// in the Base64 string.
+//
+// The string is an encoded JSON string returned by SignedBase64
+func FromSignedBase64(base64String, key string) (Map, error) {
+	parts := strings.Split(base64String, SignatureSeparator)
+	if len(parts) != 2 {
+		return nil, errors.New("objx: Signed base64 string is malformed")
+	}
+
+	sig := HashWithKey(parts[0], key)
+	if parts[1] != sig {
+		return nil, errors.New("objx: Signature for base64 data does not match")
+	}
+	return FromBase64(parts[0])
+}
+
+// MustFromSignedBase64 creates a new Obj containing the data specified
+// in the Base64 string and panics if there is an error.
+//
+// The string is an encoded JSON string returned by Base64
+func MustFromSignedBase64(base64String, key string) Map {
+	result, err := FromSignedBase64(base64String, key)
+	if err != nil {
+		panic("objx: MustFromSignedBase64 failed with error: " + err.Error())
+	}
+	return result
+}
+
+// FromURLQuery generates a new Obj by parsing the specified
+// query.
+//
+// For queries with multiple values, the first value is selected.
+func FromURLQuery(query string) (Map, error) {
+	vals, err := url.ParseQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	m := Map{}
+	for k, vals := range vals {
+		m[k] = vals[0]
+	}
+	return m, nil
+}
+
+// MustFromURLQuery generates a new Obj by parsing the specified
+// query.
+//
+// For queries with multiple values, the first value is selected.
+//
+// Panics if it encounters an error
+func MustFromURLQuery(query string) Map {
+	o, err := FromURLQuery(query)
+	if err != nil {
+		panic("objx: MustFromURLQuery failed with error: " + err.Error())
+	}
+	return o
+}

--- a/vendor/github.com/stretchr/objx/mutations.go
+++ b/vendor/github.com/stretchr/objx/mutations.go
@@ -1,0 +1,77 @@
+package objx
+
+// Exclude returns a new Map with the keys in the specified []string
+// excluded.
+func (m Map) Exclude(exclude []string) Map {
+	excluded := make(Map)
+	for k, v := range m {
+		if !contains(exclude, k) {
+			excluded[k] = v
+		}
+	}
+	return excluded
+}
+
+// Copy creates a shallow copy of the Obj.
+func (m Map) Copy() Map {
+	copied := Map{}
+	for k, v := range m {
+		copied[k] = v
+	}
+	return copied
+}
+
+// Merge blends the specified map with a copy of this map and returns the result.
+//
+// Keys that appear in both will be selected from the specified map.
+// This method requires that the wrapped object be a map[string]interface{}
+func (m Map) Merge(merge Map) Map {
+	return m.Copy().MergeHere(merge)
+}
+
+// MergeHere blends the specified map with this map and returns the current map.
+//
+// Keys that appear in both will be selected from the specified map. The original map
+// will be modified. This method requires that
+// the wrapped object be a map[string]interface{}
+func (m Map) MergeHere(merge Map) Map {
+	for k, v := range merge {
+		m[k] = v
+	}
+	return m
+}
+
+// Transform builds a new Obj giving the transformer a chance
+// to change the keys and values as it goes. This method requires that
+// the wrapped object be a map[string]interface{}
+func (m Map) Transform(transformer func(key string, value interface{}) (string, interface{})) Map {
+	newMap := Map{}
+	for k, v := range m {
+		modifiedKey, modifiedVal := transformer(k, v)
+		newMap[modifiedKey] = modifiedVal
+	}
+	return newMap
+}
+
+// TransformKeys builds a new map using the specified key mapping.
+//
+// Unspecified keys will be unaltered.
+// This method requires that the wrapped object be a map[string]interface{}
+func (m Map) TransformKeys(mapping map[string]string) Map {
+	return m.Transform(func(key string, value interface{}) (string, interface{}) {
+		if newKey, ok := mapping[key]; ok {
+			return newKey, value
+		}
+		return key, value
+	})
+}
+
+// Checks if a string slice contains a string
+func contains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/vendor/github.com/stretchr/objx/security.go
+++ b/vendor/github.com/stretchr/objx/security.go
@@ -1,0 +1,12 @@
+package objx
+
+import (
+	"crypto/sha1"
+	"encoding/hex"
+)
+
+// HashWithKey hashes the specified string using the security key
+func HashWithKey(data, key string) string {
+	d := sha1.Sum([]byte(data + ":" + key))
+	return hex.EncodeToString(d[:])
+}

--- a/vendor/github.com/stretchr/objx/tests.go
+++ b/vendor/github.com/stretchr/objx/tests.go
@@ -1,0 +1,17 @@
+package objx
+
+// Has gets whether there is something at the specified selector
+// or not.
+//
+// If m is nil, Has will always return false.
+func (m Map) Has(selector string) bool {
+	if m == nil {
+		return false
+	}
+	return !m.Get(selector).IsNil()
+}
+
+// IsNil gets whether the data is nil or not.
+func (v *Value) IsNil() bool {
+	return v == nil || v.data == nil
+}

--- a/vendor/github.com/stretchr/objx/type_specific.go
+++ b/vendor/github.com/stretchr/objx/type_specific.go
@@ -1,0 +1,346 @@
+package objx
+
+/*
+   MSI (map[string]interface{} and []map[string]interface{})
+*/
+
+// MSI gets the value as a map[string]interface{}, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) MSI(optionalDefault ...map[string]interface{}) map[string]interface{} {
+	if s, ok := v.data.(map[string]interface{}); ok {
+		return s
+	}
+	if s, ok := v.data.(Map); ok {
+		return map[string]interface{}(s)
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustMSI gets the value as a map[string]interface{}.
+//
+// Panics if the object is not a map[string]interface{}.
+func (v *Value) MustMSI() map[string]interface{} {
+	if s, ok := v.data.(Map); ok {
+		return map[string]interface{}(s)
+	}
+	return v.data.(map[string]interface{})
+}
+
+// MSISlice gets the value as a []map[string]interface{}, returns the optionalDefault
+// value or nil if the value is not a []map[string]interface{}.
+func (v *Value) MSISlice(optionalDefault ...[]map[string]interface{}) []map[string]interface{} {
+	if s, ok := v.data.([]map[string]interface{}); ok {
+		return s
+	}
+
+	s := v.ObjxMapSlice()
+	if s == nil {
+		if len(optionalDefault) == 1 {
+			return optionalDefault[0]
+		}
+		return nil
+	}
+
+	result := make([]map[string]interface{}, len(s))
+	for i := range s {
+		result[i] = s[i].Value().MSI()
+	}
+	return result
+}
+
+// MustMSISlice gets the value as a []map[string]interface{}.
+//
+// Panics if the object is not a []map[string]interface{}.
+func (v *Value) MustMSISlice() []map[string]interface{} {
+	if s := v.MSISlice(); s != nil {
+		return s
+	}
+
+	return v.data.([]map[string]interface{})
+}
+
+// IsMSI gets whether the object contained is a map[string]interface{} or not.
+func (v *Value) IsMSI() bool {
+	_, ok := v.data.(map[string]interface{})
+	if !ok {
+		_, ok = v.data.(Map)
+	}
+	return ok
+}
+
+// IsMSISlice gets whether the object contained is a []map[string]interface{} or not.
+func (v *Value) IsMSISlice() bool {
+	_, ok := v.data.([]map[string]interface{})
+	if !ok {
+		_, ok = v.data.([]Map)
+		if !ok {
+			s, ok := v.data.([]interface{})
+			if ok {
+				for i := range s {
+					switch s[i].(type) {
+					case Map:
+					case map[string]interface{}:
+					default:
+						return false
+					}
+				}
+				return true
+			}
+		}
+	}
+	return ok
+}
+
+// EachMSI calls the specified callback for each object
+// in the []map[string]interface{}.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachMSI(callback func(int, map[string]interface{}) bool) *Value {
+	for index, val := range v.MustMSISlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereMSI uses the specified decider function to select items
+// from the []map[string]interface{}.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereMSI(decider func(int, map[string]interface{}) bool) *Value {
+	var selected []map[string]interface{}
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupMSI uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]map[string]interface{}.
+func (v *Value) GroupMSI(grouper func(int, map[string]interface{}) string) *Value {
+	groups := make(map[string][]map[string]interface{})
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]map[string]interface{}, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceMSI uses the specified function to replace each map[string]interface{}s
+// by iterating each item.  The data in the returned result will be a
+// []map[string]interface{} containing the replaced items.
+func (v *Value) ReplaceMSI(replacer func(int, map[string]interface{}) map[string]interface{}) *Value {
+	arr := v.MustMSISlice()
+	replaced := make([]map[string]interface{}, len(arr))
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectMSI uses the specified collector function to collect a value
+// for each of the map[string]interface{}s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectMSI(collector func(int, map[string]interface{}) interface{}) *Value {
+	arr := v.MustMSISlice()
+	collected := make([]interface{}, len(arr))
+	v.EachMSI(func(index int, val map[string]interface{}) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   ObjxMap ((Map) and [](Map))
+*/
+
+// ObjxMap gets the value as a (Map), returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) ObjxMap(optionalDefault ...(Map)) Map {
+	if s, ok := v.data.((Map)); ok {
+		return s
+	}
+	if s, ok := v.data.(map[string]interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return New(nil)
+}
+
+// MustObjxMap gets the value as a (Map).
+//
+// Panics if the object is not a (Map).
+func (v *Value) MustObjxMap() Map {
+	if s, ok := v.data.(map[string]interface{}); ok {
+		return s
+	}
+	return v.data.((Map))
+}
+
+// ObjxMapSlice gets the value as a [](Map), returns the optionalDefault
+// value or nil if the value is not a [](Map).
+func (v *Value) ObjxMapSlice(optionalDefault ...[](Map)) [](Map) {
+	if s, ok := v.data.([]Map); ok {
+		return s
+	}
+
+	if s, ok := v.data.([]map[string]interface{}); ok {
+		result := make([]Map, len(s))
+		for i := range s {
+			result[i] = s[i]
+		}
+		return result
+	}
+
+	s, ok := v.data.([]interface{})
+	if !ok {
+		if len(optionalDefault) == 1 {
+			return optionalDefault[0]
+		}
+		return nil
+	}
+
+	result := make([]Map, len(s))
+	for i := range s {
+		switch s[i].(type) {
+		case Map:
+			result[i] = s[i].(Map)
+		case map[string]interface{}:
+			result[i] = New(s[i])
+		default:
+			return nil
+		}
+	}
+	return result
+}
+
+// MustObjxMapSlice gets the value as a [](Map).
+//
+// Panics if the object is not a [](Map).
+func (v *Value) MustObjxMapSlice() [](Map) {
+	if s := v.ObjxMapSlice(); s != nil {
+		return s
+	}
+	return v.data.([](Map))
+}
+
+// IsObjxMap gets whether the object contained is a (Map) or not.
+func (v *Value) IsObjxMap() bool {
+	_, ok := v.data.((Map))
+	if !ok {
+		_, ok = v.data.(map[string]interface{})
+	}
+	return ok
+}
+
+// IsObjxMapSlice gets whether the object contained is a [](Map) or not.
+func (v *Value) IsObjxMapSlice() bool {
+	_, ok := v.data.([](Map))
+	if !ok {
+		_, ok = v.data.([]map[string]interface{})
+		if !ok {
+			s, ok := v.data.([]interface{})
+			if ok {
+				for i := range s {
+					switch s[i].(type) {
+					case Map:
+					case map[string]interface{}:
+					default:
+						return false
+					}
+				}
+				return true
+			}
+		}
+	}
+
+	return ok
+}
+
+// EachObjxMap calls the specified callback for each object
+// in the [](Map).
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachObjxMap(callback func(int, Map) bool) *Value {
+	for index, val := range v.MustObjxMapSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereObjxMap uses the specified decider function to select items
+// from the [](Map).  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereObjxMap(decider func(int, Map) bool) *Value {
+	var selected [](Map)
+	v.EachObjxMap(func(index int, val Map) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupObjxMap uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][](Map).
+func (v *Value) GroupObjxMap(grouper func(int, Map) string) *Value {
+	groups := make(map[string][](Map))
+	v.EachObjxMap(func(index int, val Map) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([](Map), 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceObjxMap uses the specified function to replace each (Map)s
+// by iterating each item.  The data in the returned result will be a
+// [](Map) containing the replaced items.
+func (v *Value) ReplaceObjxMap(replacer func(int, Map) Map) *Value {
+	arr := v.MustObjxMapSlice()
+	replaced := make([](Map), len(arr))
+	v.EachObjxMap(func(index int, val Map) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectObjxMap uses the specified collector function to collect a value
+// for each of the (Map)s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectObjxMap(collector func(int, Map) interface{}) *Value {
+	arr := v.MustObjxMapSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachObjxMap(func(index int, val Map) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}

--- a/vendor/github.com/stretchr/objx/type_specific_codegen.go
+++ b/vendor/github.com/stretchr/objx/type_specific_codegen.go
@@ -1,0 +1,2251 @@
+package objx
+
+/*
+   Inter (interface{} and []interface{})
+*/
+
+// Inter gets the value as a interface{}, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Inter(optionalDefault ...interface{}) interface{} {
+	if s, ok := v.data.(interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInter gets the value as a interface{}.
+//
+// Panics if the object is not a interface{}.
+func (v *Value) MustInter() interface{} {
+	return v.data.(interface{})
+}
+
+// InterSlice gets the value as a []interface{}, returns the optionalDefault
+// value or nil if the value is not a []interface{}.
+func (v *Value) InterSlice(optionalDefault ...[]interface{}) []interface{} {
+	if s, ok := v.data.([]interface{}); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInterSlice gets the value as a []interface{}.
+//
+// Panics if the object is not a []interface{}.
+func (v *Value) MustInterSlice() []interface{} {
+	return v.data.([]interface{})
+}
+
+// IsInter gets whether the object contained is a interface{} or not.
+func (v *Value) IsInter() bool {
+	_, ok := v.data.(interface{})
+	return ok
+}
+
+// IsInterSlice gets whether the object contained is a []interface{} or not.
+func (v *Value) IsInterSlice() bool {
+	_, ok := v.data.([]interface{})
+	return ok
+}
+
+// EachInter calls the specified callback for each object
+// in the []interface{}.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInter(callback func(int, interface{}) bool) *Value {
+	for index, val := range v.MustInterSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInter uses the specified decider function to select items
+// from the []interface{}.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInter(decider func(int, interface{}) bool) *Value {
+	var selected []interface{}
+	v.EachInter(func(index int, val interface{}) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInter uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]interface{}.
+func (v *Value) GroupInter(grouper func(int, interface{}) string) *Value {
+	groups := make(map[string][]interface{})
+	v.EachInter(func(index int, val interface{}) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]interface{}, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInter uses the specified function to replace each interface{}s
+// by iterating each item.  The data in the returned result will be a
+// []interface{} containing the replaced items.
+func (v *Value) ReplaceInter(replacer func(int, interface{}) interface{}) *Value {
+	arr := v.MustInterSlice()
+	replaced := make([]interface{}, len(arr))
+	v.EachInter(func(index int, val interface{}) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInter uses the specified collector function to collect a value
+// for each of the interface{}s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInter(collector func(int, interface{}) interface{}) *Value {
+	arr := v.MustInterSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachInter(func(index int, val interface{}) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Bool (bool and []bool)
+*/
+
+// Bool gets the value as a bool, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Bool(optionalDefault ...bool) bool {
+	if s, ok := v.data.(bool); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return false
+}
+
+// MustBool gets the value as a bool.
+//
+// Panics if the object is not a bool.
+func (v *Value) MustBool() bool {
+	return v.data.(bool)
+}
+
+// BoolSlice gets the value as a []bool, returns the optionalDefault
+// value or nil if the value is not a []bool.
+func (v *Value) BoolSlice(optionalDefault ...[]bool) []bool {
+	if s, ok := v.data.([]bool); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustBoolSlice gets the value as a []bool.
+//
+// Panics if the object is not a []bool.
+func (v *Value) MustBoolSlice() []bool {
+	return v.data.([]bool)
+}
+
+// IsBool gets whether the object contained is a bool or not.
+func (v *Value) IsBool() bool {
+	_, ok := v.data.(bool)
+	return ok
+}
+
+// IsBoolSlice gets whether the object contained is a []bool or not.
+func (v *Value) IsBoolSlice() bool {
+	_, ok := v.data.([]bool)
+	return ok
+}
+
+// EachBool calls the specified callback for each object
+// in the []bool.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachBool(callback func(int, bool) bool) *Value {
+	for index, val := range v.MustBoolSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereBool uses the specified decider function to select items
+// from the []bool.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereBool(decider func(int, bool) bool) *Value {
+	var selected []bool
+	v.EachBool(func(index int, val bool) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupBool uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]bool.
+func (v *Value) GroupBool(grouper func(int, bool) string) *Value {
+	groups := make(map[string][]bool)
+	v.EachBool(func(index int, val bool) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]bool, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceBool uses the specified function to replace each bools
+// by iterating each item.  The data in the returned result will be a
+// []bool containing the replaced items.
+func (v *Value) ReplaceBool(replacer func(int, bool) bool) *Value {
+	arr := v.MustBoolSlice()
+	replaced := make([]bool, len(arr))
+	v.EachBool(func(index int, val bool) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectBool uses the specified collector function to collect a value
+// for each of the bools in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectBool(collector func(int, bool) interface{}) *Value {
+	arr := v.MustBoolSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachBool(func(index int, val bool) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Str (string and []string)
+*/
+
+// Str gets the value as a string, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Str(optionalDefault ...string) string {
+	if s, ok := v.data.(string); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return ""
+}
+
+// MustStr gets the value as a string.
+//
+// Panics if the object is not a string.
+func (v *Value) MustStr() string {
+	return v.data.(string)
+}
+
+// StrSlice gets the value as a []string, returns the optionalDefault
+// value or nil if the value is not a []string.
+func (v *Value) StrSlice(optionalDefault ...[]string) []string {
+	if s, ok := v.data.([]string); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustStrSlice gets the value as a []string.
+//
+// Panics if the object is not a []string.
+func (v *Value) MustStrSlice() []string {
+	return v.data.([]string)
+}
+
+// IsStr gets whether the object contained is a string or not.
+func (v *Value) IsStr() bool {
+	_, ok := v.data.(string)
+	return ok
+}
+
+// IsStrSlice gets whether the object contained is a []string or not.
+func (v *Value) IsStrSlice() bool {
+	_, ok := v.data.([]string)
+	return ok
+}
+
+// EachStr calls the specified callback for each object
+// in the []string.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachStr(callback func(int, string) bool) *Value {
+	for index, val := range v.MustStrSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereStr uses the specified decider function to select items
+// from the []string.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereStr(decider func(int, string) bool) *Value {
+	var selected []string
+	v.EachStr(func(index int, val string) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupStr uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]string.
+func (v *Value) GroupStr(grouper func(int, string) string) *Value {
+	groups := make(map[string][]string)
+	v.EachStr(func(index int, val string) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]string, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceStr uses the specified function to replace each strings
+// by iterating each item.  The data in the returned result will be a
+// []string containing the replaced items.
+func (v *Value) ReplaceStr(replacer func(int, string) string) *Value {
+	arr := v.MustStrSlice()
+	replaced := make([]string, len(arr))
+	v.EachStr(func(index int, val string) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectStr uses the specified collector function to collect a value
+// for each of the strings in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectStr(collector func(int, string) interface{}) *Value {
+	arr := v.MustStrSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachStr(func(index int, val string) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Int (int and []int)
+*/
+
+// Int gets the value as a int, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int(optionalDefault ...int) int {
+	if s, ok := v.data.(int); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt gets the value as a int.
+//
+// Panics if the object is not a int.
+func (v *Value) MustInt() int {
+	return v.data.(int)
+}
+
+// IntSlice gets the value as a []int, returns the optionalDefault
+// value or nil if the value is not a []int.
+func (v *Value) IntSlice(optionalDefault ...[]int) []int {
+	if s, ok := v.data.([]int); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustIntSlice gets the value as a []int.
+//
+// Panics if the object is not a []int.
+func (v *Value) MustIntSlice() []int {
+	return v.data.([]int)
+}
+
+// IsInt gets whether the object contained is a int or not.
+func (v *Value) IsInt() bool {
+	_, ok := v.data.(int)
+	return ok
+}
+
+// IsIntSlice gets whether the object contained is a []int or not.
+func (v *Value) IsIntSlice() bool {
+	_, ok := v.data.([]int)
+	return ok
+}
+
+// EachInt calls the specified callback for each object
+// in the []int.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt(callback func(int, int) bool) *Value {
+	for index, val := range v.MustIntSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt uses the specified decider function to select items
+// from the []int.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt(decider func(int, int) bool) *Value {
+	var selected []int
+	v.EachInt(func(index int, val int) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int.
+func (v *Value) GroupInt(grouper func(int, int) string) *Value {
+	groups := make(map[string][]int)
+	v.EachInt(func(index int, val int) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt uses the specified function to replace each ints
+// by iterating each item.  The data in the returned result will be a
+// []int containing the replaced items.
+func (v *Value) ReplaceInt(replacer func(int, int) int) *Value {
+	arr := v.MustIntSlice()
+	replaced := make([]int, len(arr))
+	v.EachInt(func(index int, val int) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt uses the specified collector function to collect a value
+// for each of the ints in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt(collector func(int, int) interface{}) *Value {
+	arr := v.MustIntSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt(func(index int, val int) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Int8 (int8 and []int8)
+*/
+
+// Int8 gets the value as a int8, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int8(optionalDefault ...int8) int8 {
+	if s, ok := v.data.(int8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt8 gets the value as a int8.
+//
+// Panics if the object is not a int8.
+func (v *Value) MustInt8() int8 {
+	return v.data.(int8)
+}
+
+// Int8Slice gets the value as a []int8, returns the optionalDefault
+// value or nil if the value is not a []int8.
+func (v *Value) Int8Slice(optionalDefault ...[]int8) []int8 {
+	if s, ok := v.data.([]int8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt8Slice gets the value as a []int8.
+//
+// Panics if the object is not a []int8.
+func (v *Value) MustInt8Slice() []int8 {
+	return v.data.([]int8)
+}
+
+// IsInt8 gets whether the object contained is a int8 or not.
+func (v *Value) IsInt8() bool {
+	_, ok := v.data.(int8)
+	return ok
+}
+
+// IsInt8Slice gets whether the object contained is a []int8 or not.
+func (v *Value) IsInt8Slice() bool {
+	_, ok := v.data.([]int8)
+	return ok
+}
+
+// EachInt8 calls the specified callback for each object
+// in the []int8.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt8(callback func(int, int8) bool) *Value {
+	for index, val := range v.MustInt8Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt8 uses the specified decider function to select items
+// from the []int8.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt8(decider func(int, int8) bool) *Value {
+	var selected []int8
+	v.EachInt8(func(index int, val int8) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt8 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int8.
+func (v *Value) GroupInt8(grouper func(int, int8) string) *Value {
+	groups := make(map[string][]int8)
+	v.EachInt8(func(index int, val int8) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int8, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt8 uses the specified function to replace each int8s
+// by iterating each item.  The data in the returned result will be a
+// []int8 containing the replaced items.
+func (v *Value) ReplaceInt8(replacer func(int, int8) int8) *Value {
+	arr := v.MustInt8Slice()
+	replaced := make([]int8, len(arr))
+	v.EachInt8(func(index int, val int8) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt8 uses the specified collector function to collect a value
+// for each of the int8s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt8(collector func(int, int8) interface{}) *Value {
+	arr := v.MustInt8Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt8(func(index int, val int8) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Int16 (int16 and []int16)
+*/
+
+// Int16 gets the value as a int16, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int16(optionalDefault ...int16) int16 {
+	if s, ok := v.data.(int16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt16 gets the value as a int16.
+//
+// Panics if the object is not a int16.
+func (v *Value) MustInt16() int16 {
+	return v.data.(int16)
+}
+
+// Int16Slice gets the value as a []int16, returns the optionalDefault
+// value or nil if the value is not a []int16.
+func (v *Value) Int16Slice(optionalDefault ...[]int16) []int16 {
+	if s, ok := v.data.([]int16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt16Slice gets the value as a []int16.
+//
+// Panics if the object is not a []int16.
+func (v *Value) MustInt16Slice() []int16 {
+	return v.data.([]int16)
+}
+
+// IsInt16 gets whether the object contained is a int16 or not.
+func (v *Value) IsInt16() bool {
+	_, ok := v.data.(int16)
+	return ok
+}
+
+// IsInt16Slice gets whether the object contained is a []int16 or not.
+func (v *Value) IsInt16Slice() bool {
+	_, ok := v.data.([]int16)
+	return ok
+}
+
+// EachInt16 calls the specified callback for each object
+// in the []int16.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt16(callback func(int, int16) bool) *Value {
+	for index, val := range v.MustInt16Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt16 uses the specified decider function to select items
+// from the []int16.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt16(decider func(int, int16) bool) *Value {
+	var selected []int16
+	v.EachInt16(func(index int, val int16) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt16 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int16.
+func (v *Value) GroupInt16(grouper func(int, int16) string) *Value {
+	groups := make(map[string][]int16)
+	v.EachInt16(func(index int, val int16) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int16, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt16 uses the specified function to replace each int16s
+// by iterating each item.  The data in the returned result will be a
+// []int16 containing the replaced items.
+func (v *Value) ReplaceInt16(replacer func(int, int16) int16) *Value {
+	arr := v.MustInt16Slice()
+	replaced := make([]int16, len(arr))
+	v.EachInt16(func(index int, val int16) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt16 uses the specified collector function to collect a value
+// for each of the int16s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt16(collector func(int, int16) interface{}) *Value {
+	arr := v.MustInt16Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt16(func(index int, val int16) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Int32 (int32 and []int32)
+*/
+
+// Int32 gets the value as a int32, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int32(optionalDefault ...int32) int32 {
+	if s, ok := v.data.(int32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt32 gets the value as a int32.
+//
+// Panics if the object is not a int32.
+func (v *Value) MustInt32() int32 {
+	return v.data.(int32)
+}
+
+// Int32Slice gets the value as a []int32, returns the optionalDefault
+// value or nil if the value is not a []int32.
+func (v *Value) Int32Slice(optionalDefault ...[]int32) []int32 {
+	if s, ok := v.data.([]int32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt32Slice gets the value as a []int32.
+//
+// Panics if the object is not a []int32.
+func (v *Value) MustInt32Slice() []int32 {
+	return v.data.([]int32)
+}
+
+// IsInt32 gets whether the object contained is a int32 or not.
+func (v *Value) IsInt32() bool {
+	_, ok := v.data.(int32)
+	return ok
+}
+
+// IsInt32Slice gets whether the object contained is a []int32 or not.
+func (v *Value) IsInt32Slice() bool {
+	_, ok := v.data.([]int32)
+	return ok
+}
+
+// EachInt32 calls the specified callback for each object
+// in the []int32.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt32(callback func(int, int32) bool) *Value {
+	for index, val := range v.MustInt32Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt32 uses the specified decider function to select items
+// from the []int32.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt32(decider func(int, int32) bool) *Value {
+	var selected []int32
+	v.EachInt32(func(index int, val int32) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt32 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int32.
+func (v *Value) GroupInt32(grouper func(int, int32) string) *Value {
+	groups := make(map[string][]int32)
+	v.EachInt32(func(index int, val int32) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int32, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt32 uses the specified function to replace each int32s
+// by iterating each item.  The data in the returned result will be a
+// []int32 containing the replaced items.
+func (v *Value) ReplaceInt32(replacer func(int, int32) int32) *Value {
+	arr := v.MustInt32Slice()
+	replaced := make([]int32, len(arr))
+	v.EachInt32(func(index int, val int32) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt32 uses the specified collector function to collect a value
+// for each of the int32s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt32(collector func(int, int32) interface{}) *Value {
+	arr := v.MustInt32Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt32(func(index int, val int32) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Int64 (int64 and []int64)
+*/
+
+// Int64 gets the value as a int64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Int64(optionalDefault ...int64) int64 {
+	if s, ok := v.data.(int64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustInt64 gets the value as a int64.
+//
+// Panics if the object is not a int64.
+func (v *Value) MustInt64() int64 {
+	return v.data.(int64)
+}
+
+// Int64Slice gets the value as a []int64, returns the optionalDefault
+// value or nil if the value is not a []int64.
+func (v *Value) Int64Slice(optionalDefault ...[]int64) []int64 {
+	if s, ok := v.data.([]int64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustInt64Slice gets the value as a []int64.
+//
+// Panics if the object is not a []int64.
+func (v *Value) MustInt64Slice() []int64 {
+	return v.data.([]int64)
+}
+
+// IsInt64 gets whether the object contained is a int64 or not.
+func (v *Value) IsInt64() bool {
+	_, ok := v.data.(int64)
+	return ok
+}
+
+// IsInt64Slice gets whether the object contained is a []int64 or not.
+func (v *Value) IsInt64Slice() bool {
+	_, ok := v.data.([]int64)
+	return ok
+}
+
+// EachInt64 calls the specified callback for each object
+// in the []int64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachInt64(callback func(int, int64) bool) *Value {
+	for index, val := range v.MustInt64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereInt64 uses the specified decider function to select items
+// from the []int64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereInt64(decider func(int, int64) bool) *Value {
+	var selected []int64
+	v.EachInt64(func(index int, val int64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupInt64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]int64.
+func (v *Value) GroupInt64(grouper func(int, int64) string) *Value {
+	groups := make(map[string][]int64)
+	v.EachInt64(func(index int, val int64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]int64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceInt64 uses the specified function to replace each int64s
+// by iterating each item.  The data in the returned result will be a
+// []int64 containing the replaced items.
+func (v *Value) ReplaceInt64(replacer func(int, int64) int64) *Value {
+	arr := v.MustInt64Slice()
+	replaced := make([]int64, len(arr))
+	v.EachInt64(func(index int, val int64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectInt64 uses the specified collector function to collect a value
+// for each of the int64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectInt64(collector func(int, int64) interface{}) *Value {
+	arr := v.MustInt64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachInt64(func(index int, val int64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Uint (uint and []uint)
+*/
+
+// Uint gets the value as a uint, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint(optionalDefault ...uint) uint {
+	if s, ok := v.data.(uint); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint gets the value as a uint.
+//
+// Panics if the object is not a uint.
+func (v *Value) MustUint() uint {
+	return v.data.(uint)
+}
+
+// UintSlice gets the value as a []uint, returns the optionalDefault
+// value or nil if the value is not a []uint.
+func (v *Value) UintSlice(optionalDefault ...[]uint) []uint {
+	if s, ok := v.data.([]uint); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUintSlice gets the value as a []uint.
+//
+// Panics if the object is not a []uint.
+func (v *Value) MustUintSlice() []uint {
+	return v.data.([]uint)
+}
+
+// IsUint gets whether the object contained is a uint or not.
+func (v *Value) IsUint() bool {
+	_, ok := v.data.(uint)
+	return ok
+}
+
+// IsUintSlice gets whether the object contained is a []uint or not.
+func (v *Value) IsUintSlice() bool {
+	_, ok := v.data.([]uint)
+	return ok
+}
+
+// EachUint calls the specified callback for each object
+// in the []uint.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint(callback func(int, uint) bool) *Value {
+	for index, val := range v.MustUintSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint uses the specified decider function to select items
+// from the []uint.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint(decider func(int, uint) bool) *Value {
+	var selected []uint
+	v.EachUint(func(index int, val uint) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint.
+func (v *Value) GroupUint(grouper func(int, uint) string) *Value {
+	groups := make(map[string][]uint)
+	v.EachUint(func(index int, val uint) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint uses the specified function to replace each uints
+// by iterating each item.  The data in the returned result will be a
+// []uint containing the replaced items.
+func (v *Value) ReplaceUint(replacer func(int, uint) uint) *Value {
+	arr := v.MustUintSlice()
+	replaced := make([]uint, len(arr))
+	v.EachUint(func(index int, val uint) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint uses the specified collector function to collect a value
+// for each of the uints in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint(collector func(int, uint) interface{}) *Value {
+	arr := v.MustUintSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint(func(index int, val uint) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Uint8 (uint8 and []uint8)
+*/
+
+// Uint8 gets the value as a uint8, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint8(optionalDefault ...uint8) uint8 {
+	if s, ok := v.data.(uint8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint8 gets the value as a uint8.
+//
+// Panics if the object is not a uint8.
+func (v *Value) MustUint8() uint8 {
+	return v.data.(uint8)
+}
+
+// Uint8Slice gets the value as a []uint8, returns the optionalDefault
+// value or nil if the value is not a []uint8.
+func (v *Value) Uint8Slice(optionalDefault ...[]uint8) []uint8 {
+	if s, ok := v.data.([]uint8); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint8Slice gets the value as a []uint8.
+//
+// Panics if the object is not a []uint8.
+func (v *Value) MustUint8Slice() []uint8 {
+	return v.data.([]uint8)
+}
+
+// IsUint8 gets whether the object contained is a uint8 or not.
+func (v *Value) IsUint8() bool {
+	_, ok := v.data.(uint8)
+	return ok
+}
+
+// IsUint8Slice gets whether the object contained is a []uint8 or not.
+func (v *Value) IsUint8Slice() bool {
+	_, ok := v.data.([]uint8)
+	return ok
+}
+
+// EachUint8 calls the specified callback for each object
+// in the []uint8.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint8(callback func(int, uint8) bool) *Value {
+	for index, val := range v.MustUint8Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint8 uses the specified decider function to select items
+// from the []uint8.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint8(decider func(int, uint8) bool) *Value {
+	var selected []uint8
+	v.EachUint8(func(index int, val uint8) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint8 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint8.
+func (v *Value) GroupUint8(grouper func(int, uint8) string) *Value {
+	groups := make(map[string][]uint8)
+	v.EachUint8(func(index int, val uint8) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint8, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint8 uses the specified function to replace each uint8s
+// by iterating each item.  The data in the returned result will be a
+// []uint8 containing the replaced items.
+func (v *Value) ReplaceUint8(replacer func(int, uint8) uint8) *Value {
+	arr := v.MustUint8Slice()
+	replaced := make([]uint8, len(arr))
+	v.EachUint8(func(index int, val uint8) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint8 uses the specified collector function to collect a value
+// for each of the uint8s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint8(collector func(int, uint8) interface{}) *Value {
+	arr := v.MustUint8Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint8(func(index int, val uint8) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Uint16 (uint16 and []uint16)
+*/
+
+// Uint16 gets the value as a uint16, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint16(optionalDefault ...uint16) uint16 {
+	if s, ok := v.data.(uint16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint16 gets the value as a uint16.
+//
+// Panics if the object is not a uint16.
+func (v *Value) MustUint16() uint16 {
+	return v.data.(uint16)
+}
+
+// Uint16Slice gets the value as a []uint16, returns the optionalDefault
+// value or nil if the value is not a []uint16.
+func (v *Value) Uint16Slice(optionalDefault ...[]uint16) []uint16 {
+	if s, ok := v.data.([]uint16); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint16Slice gets the value as a []uint16.
+//
+// Panics if the object is not a []uint16.
+func (v *Value) MustUint16Slice() []uint16 {
+	return v.data.([]uint16)
+}
+
+// IsUint16 gets whether the object contained is a uint16 or not.
+func (v *Value) IsUint16() bool {
+	_, ok := v.data.(uint16)
+	return ok
+}
+
+// IsUint16Slice gets whether the object contained is a []uint16 or not.
+func (v *Value) IsUint16Slice() bool {
+	_, ok := v.data.([]uint16)
+	return ok
+}
+
+// EachUint16 calls the specified callback for each object
+// in the []uint16.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint16(callback func(int, uint16) bool) *Value {
+	for index, val := range v.MustUint16Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint16 uses the specified decider function to select items
+// from the []uint16.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint16(decider func(int, uint16) bool) *Value {
+	var selected []uint16
+	v.EachUint16(func(index int, val uint16) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint16 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint16.
+func (v *Value) GroupUint16(grouper func(int, uint16) string) *Value {
+	groups := make(map[string][]uint16)
+	v.EachUint16(func(index int, val uint16) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint16, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint16 uses the specified function to replace each uint16s
+// by iterating each item.  The data in the returned result will be a
+// []uint16 containing the replaced items.
+func (v *Value) ReplaceUint16(replacer func(int, uint16) uint16) *Value {
+	arr := v.MustUint16Slice()
+	replaced := make([]uint16, len(arr))
+	v.EachUint16(func(index int, val uint16) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint16 uses the specified collector function to collect a value
+// for each of the uint16s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint16(collector func(int, uint16) interface{}) *Value {
+	arr := v.MustUint16Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint16(func(index int, val uint16) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Uint32 (uint32 and []uint32)
+*/
+
+// Uint32 gets the value as a uint32, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint32(optionalDefault ...uint32) uint32 {
+	if s, ok := v.data.(uint32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint32 gets the value as a uint32.
+//
+// Panics if the object is not a uint32.
+func (v *Value) MustUint32() uint32 {
+	return v.data.(uint32)
+}
+
+// Uint32Slice gets the value as a []uint32, returns the optionalDefault
+// value or nil if the value is not a []uint32.
+func (v *Value) Uint32Slice(optionalDefault ...[]uint32) []uint32 {
+	if s, ok := v.data.([]uint32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint32Slice gets the value as a []uint32.
+//
+// Panics if the object is not a []uint32.
+func (v *Value) MustUint32Slice() []uint32 {
+	return v.data.([]uint32)
+}
+
+// IsUint32 gets whether the object contained is a uint32 or not.
+func (v *Value) IsUint32() bool {
+	_, ok := v.data.(uint32)
+	return ok
+}
+
+// IsUint32Slice gets whether the object contained is a []uint32 or not.
+func (v *Value) IsUint32Slice() bool {
+	_, ok := v.data.([]uint32)
+	return ok
+}
+
+// EachUint32 calls the specified callback for each object
+// in the []uint32.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint32(callback func(int, uint32) bool) *Value {
+	for index, val := range v.MustUint32Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint32 uses the specified decider function to select items
+// from the []uint32.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint32(decider func(int, uint32) bool) *Value {
+	var selected []uint32
+	v.EachUint32(func(index int, val uint32) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint32 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint32.
+func (v *Value) GroupUint32(grouper func(int, uint32) string) *Value {
+	groups := make(map[string][]uint32)
+	v.EachUint32(func(index int, val uint32) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint32, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint32 uses the specified function to replace each uint32s
+// by iterating each item.  The data in the returned result will be a
+// []uint32 containing the replaced items.
+func (v *Value) ReplaceUint32(replacer func(int, uint32) uint32) *Value {
+	arr := v.MustUint32Slice()
+	replaced := make([]uint32, len(arr))
+	v.EachUint32(func(index int, val uint32) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint32 uses the specified collector function to collect a value
+// for each of the uint32s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint32(collector func(int, uint32) interface{}) *Value {
+	arr := v.MustUint32Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint32(func(index int, val uint32) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Uint64 (uint64 and []uint64)
+*/
+
+// Uint64 gets the value as a uint64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uint64(optionalDefault ...uint64) uint64 {
+	if s, ok := v.data.(uint64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUint64 gets the value as a uint64.
+//
+// Panics if the object is not a uint64.
+func (v *Value) MustUint64() uint64 {
+	return v.data.(uint64)
+}
+
+// Uint64Slice gets the value as a []uint64, returns the optionalDefault
+// value or nil if the value is not a []uint64.
+func (v *Value) Uint64Slice(optionalDefault ...[]uint64) []uint64 {
+	if s, ok := v.data.([]uint64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUint64Slice gets the value as a []uint64.
+//
+// Panics if the object is not a []uint64.
+func (v *Value) MustUint64Slice() []uint64 {
+	return v.data.([]uint64)
+}
+
+// IsUint64 gets whether the object contained is a uint64 or not.
+func (v *Value) IsUint64() bool {
+	_, ok := v.data.(uint64)
+	return ok
+}
+
+// IsUint64Slice gets whether the object contained is a []uint64 or not.
+func (v *Value) IsUint64Slice() bool {
+	_, ok := v.data.([]uint64)
+	return ok
+}
+
+// EachUint64 calls the specified callback for each object
+// in the []uint64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUint64(callback func(int, uint64) bool) *Value {
+	for index, val := range v.MustUint64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUint64 uses the specified decider function to select items
+// from the []uint64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUint64(decider func(int, uint64) bool) *Value {
+	var selected []uint64
+	v.EachUint64(func(index int, val uint64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUint64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uint64.
+func (v *Value) GroupUint64(grouper func(int, uint64) string) *Value {
+	groups := make(map[string][]uint64)
+	v.EachUint64(func(index int, val uint64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uint64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUint64 uses the specified function to replace each uint64s
+// by iterating each item.  The data in the returned result will be a
+// []uint64 containing the replaced items.
+func (v *Value) ReplaceUint64(replacer func(int, uint64) uint64) *Value {
+	arr := v.MustUint64Slice()
+	replaced := make([]uint64, len(arr))
+	v.EachUint64(func(index int, val uint64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUint64 uses the specified collector function to collect a value
+// for each of the uint64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUint64(collector func(int, uint64) interface{}) *Value {
+	arr := v.MustUint64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachUint64(func(index int, val uint64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Uintptr (uintptr and []uintptr)
+*/
+
+// Uintptr gets the value as a uintptr, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Uintptr(optionalDefault ...uintptr) uintptr {
+	if s, ok := v.data.(uintptr); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustUintptr gets the value as a uintptr.
+//
+// Panics if the object is not a uintptr.
+func (v *Value) MustUintptr() uintptr {
+	return v.data.(uintptr)
+}
+
+// UintptrSlice gets the value as a []uintptr, returns the optionalDefault
+// value or nil if the value is not a []uintptr.
+func (v *Value) UintptrSlice(optionalDefault ...[]uintptr) []uintptr {
+	if s, ok := v.data.([]uintptr); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustUintptrSlice gets the value as a []uintptr.
+//
+// Panics if the object is not a []uintptr.
+func (v *Value) MustUintptrSlice() []uintptr {
+	return v.data.([]uintptr)
+}
+
+// IsUintptr gets whether the object contained is a uintptr or not.
+func (v *Value) IsUintptr() bool {
+	_, ok := v.data.(uintptr)
+	return ok
+}
+
+// IsUintptrSlice gets whether the object contained is a []uintptr or not.
+func (v *Value) IsUintptrSlice() bool {
+	_, ok := v.data.([]uintptr)
+	return ok
+}
+
+// EachUintptr calls the specified callback for each object
+// in the []uintptr.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachUintptr(callback func(int, uintptr) bool) *Value {
+	for index, val := range v.MustUintptrSlice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereUintptr uses the specified decider function to select items
+// from the []uintptr.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereUintptr(decider func(int, uintptr) bool) *Value {
+	var selected []uintptr
+	v.EachUintptr(func(index int, val uintptr) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupUintptr uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]uintptr.
+func (v *Value) GroupUintptr(grouper func(int, uintptr) string) *Value {
+	groups := make(map[string][]uintptr)
+	v.EachUintptr(func(index int, val uintptr) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]uintptr, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceUintptr uses the specified function to replace each uintptrs
+// by iterating each item.  The data in the returned result will be a
+// []uintptr containing the replaced items.
+func (v *Value) ReplaceUintptr(replacer func(int, uintptr) uintptr) *Value {
+	arr := v.MustUintptrSlice()
+	replaced := make([]uintptr, len(arr))
+	v.EachUintptr(func(index int, val uintptr) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectUintptr uses the specified collector function to collect a value
+// for each of the uintptrs in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectUintptr(collector func(int, uintptr) interface{}) *Value {
+	arr := v.MustUintptrSlice()
+	collected := make([]interface{}, len(arr))
+	v.EachUintptr(func(index int, val uintptr) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Float32 (float32 and []float32)
+*/
+
+// Float32 gets the value as a float32, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Float32(optionalDefault ...float32) float32 {
+	if s, ok := v.data.(float32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustFloat32 gets the value as a float32.
+//
+// Panics if the object is not a float32.
+func (v *Value) MustFloat32() float32 {
+	return v.data.(float32)
+}
+
+// Float32Slice gets the value as a []float32, returns the optionalDefault
+// value or nil if the value is not a []float32.
+func (v *Value) Float32Slice(optionalDefault ...[]float32) []float32 {
+	if s, ok := v.data.([]float32); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustFloat32Slice gets the value as a []float32.
+//
+// Panics if the object is not a []float32.
+func (v *Value) MustFloat32Slice() []float32 {
+	return v.data.([]float32)
+}
+
+// IsFloat32 gets whether the object contained is a float32 or not.
+func (v *Value) IsFloat32() bool {
+	_, ok := v.data.(float32)
+	return ok
+}
+
+// IsFloat32Slice gets whether the object contained is a []float32 or not.
+func (v *Value) IsFloat32Slice() bool {
+	_, ok := v.data.([]float32)
+	return ok
+}
+
+// EachFloat32 calls the specified callback for each object
+// in the []float32.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachFloat32(callback func(int, float32) bool) *Value {
+	for index, val := range v.MustFloat32Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereFloat32 uses the specified decider function to select items
+// from the []float32.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereFloat32(decider func(int, float32) bool) *Value {
+	var selected []float32
+	v.EachFloat32(func(index int, val float32) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupFloat32 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]float32.
+func (v *Value) GroupFloat32(grouper func(int, float32) string) *Value {
+	groups := make(map[string][]float32)
+	v.EachFloat32(func(index int, val float32) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]float32, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceFloat32 uses the specified function to replace each float32s
+// by iterating each item.  The data in the returned result will be a
+// []float32 containing the replaced items.
+func (v *Value) ReplaceFloat32(replacer func(int, float32) float32) *Value {
+	arr := v.MustFloat32Slice()
+	replaced := make([]float32, len(arr))
+	v.EachFloat32(func(index int, val float32) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectFloat32 uses the specified collector function to collect a value
+// for each of the float32s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectFloat32(collector func(int, float32) interface{}) *Value {
+	arr := v.MustFloat32Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachFloat32(func(index int, val float32) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Float64 (float64 and []float64)
+*/
+
+// Float64 gets the value as a float64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Float64(optionalDefault ...float64) float64 {
+	if s, ok := v.data.(float64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustFloat64 gets the value as a float64.
+//
+// Panics if the object is not a float64.
+func (v *Value) MustFloat64() float64 {
+	return v.data.(float64)
+}
+
+// Float64Slice gets the value as a []float64, returns the optionalDefault
+// value or nil if the value is not a []float64.
+func (v *Value) Float64Slice(optionalDefault ...[]float64) []float64 {
+	if s, ok := v.data.([]float64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustFloat64Slice gets the value as a []float64.
+//
+// Panics if the object is not a []float64.
+func (v *Value) MustFloat64Slice() []float64 {
+	return v.data.([]float64)
+}
+
+// IsFloat64 gets whether the object contained is a float64 or not.
+func (v *Value) IsFloat64() bool {
+	_, ok := v.data.(float64)
+	return ok
+}
+
+// IsFloat64Slice gets whether the object contained is a []float64 or not.
+func (v *Value) IsFloat64Slice() bool {
+	_, ok := v.data.([]float64)
+	return ok
+}
+
+// EachFloat64 calls the specified callback for each object
+// in the []float64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachFloat64(callback func(int, float64) bool) *Value {
+	for index, val := range v.MustFloat64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereFloat64 uses the specified decider function to select items
+// from the []float64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereFloat64(decider func(int, float64) bool) *Value {
+	var selected []float64
+	v.EachFloat64(func(index int, val float64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupFloat64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]float64.
+func (v *Value) GroupFloat64(grouper func(int, float64) string) *Value {
+	groups := make(map[string][]float64)
+	v.EachFloat64(func(index int, val float64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]float64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceFloat64 uses the specified function to replace each float64s
+// by iterating each item.  The data in the returned result will be a
+// []float64 containing the replaced items.
+func (v *Value) ReplaceFloat64(replacer func(int, float64) float64) *Value {
+	arr := v.MustFloat64Slice()
+	replaced := make([]float64, len(arr))
+	v.EachFloat64(func(index int, val float64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectFloat64 uses the specified collector function to collect a value
+// for each of the float64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectFloat64(collector func(int, float64) interface{}) *Value {
+	arr := v.MustFloat64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachFloat64(func(index int, val float64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Complex64 (complex64 and []complex64)
+*/
+
+// Complex64 gets the value as a complex64, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Complex64(optionalDefault ...complex64) complex64 {
+	if s, ok := v.data.(complex64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustComplex64 gets the value as a complex64.
+//
+// Panics if the object is not a complex64.
+func (v *Value) MustComplex64() complex64 {
+	return v.data.(complex64)
+}
+
+// Complex64Slice gets the value as a []complex64, returns the optionalDefault
+// value or nil if the value is not a []complex64.
+func (v *Value) Complex64Slice(optionalDefault ...[]complex64) []complex64 {
+	if s, ok := v.data.([]complex64); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustComplex64Slice gets the value as a []complex64.
+//
+// Panics if the object is not a []complex64.
+func (v *Value) MustComplex64Slice() []complex64 {
+	return v.data.([]complex64)
+}
+
+// IsComplex64 gets whether the object contained is a complex64 or not.
+func (v *Value) IsComplex64() bool {
+	_, ok := v.data.(complex64)
+	return ok
+}
+
+// IsComplex64Slice gets whether the object contained is a []complex64 or not.
+func (v *Value) IsComplex64Slice() bool {
+	_, ok := v.data.([]complex64)
+	return ok
+}
+
+// EachComplex64 calls the specified callback for each object
+// in the []complex64.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachComplex64(callback func(int, complex64) bool) *Value {
+	for index, val := range v.MustComplex64Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereComplex64 uses the specified decider function to select items
+// from the []complex64.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereComplex64(decider func(int, complex64) bool) *Value {
+	var selected []complex64
+	v.EachComplex64(func(index int, val complex64) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupComplex64 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]complex64.
+func (v *Value) GroupComplex64(grouper func(int, complex64) string) *Value {
+	groups := make(map[string][]complex64)
+	v.EachComplex64(func(index int, val complex64) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]complex64, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceComplex64 uses the specified function to replace each complex64s
+// by iterating each item.  The data in the returned result will be a
+// []complex64 containing the replaced items.
+func (v *Value) ReplaceComplex64(replacer func(int, complex64) complex64) *Value {
+	arr := v.MustComplex64Slice()
+	replaced := make([]complex64, len(arr))
+	v.EachComplex64(func(index int, val complex64) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectComplex64 uses the specified collector function to collect a value
+// for each of the complex64s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectComplex64(collector func(int, complex64) interface{}) *Value {
+	arr := v.MustComplex64Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachComplex64(func(index int, val complex64) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}
+
+/*
+   Complex128 (complex128 and []complex128)
+*/
+
+// Complex128 gets the value as a complex128, returns the optionalDefault
+// value or a system default object if the value is the wrong type.
+func (v *Value) Complex128(optionalDefault ...complex128) complex128 {
+	if s, ok := v.data.(complex128); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return 0
+}
+
+// MustComplex128 gets the value as a complex128.
+//
+// Panics if the object is not a complex128.
+func (v *Value) MustComplex128() complex128 {
+	return v.data.(complex128)
+}
+
+// Complex128Slice gets the value as a []complex128, returns the optionalDefault
+// value or nil if the value is not a []complex128.
+func (v *Value) Complex128Slice(optionalDefault ...[]complex128) []complex128 {
+	if s, ok := v.data.([]complex128); ok {
+		return s
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+	return nil
+}
+
+// MustComplex128Slice gets the value as a []complex128.
+//
+// Panics if the object is not a []complex128.
+func (v *Value) MustComplex128Slice() []complex128 {
+	return v.data.([]complex128)
+}
+
+// IsComplex128 gets whether the object contained is a complex128 or not.
+func (v *Value) IsComplex128() bool {
+	_, ok := v.data.(complex128)
+	return ok
+}
+
+// IsComplex128Slice gets whether the object contained is a []complex128 or not.
+func (v *Value) IsComplex128Slice() bool {
+	_, ok := v.data.([]complex128)
+	return ok
+}
+
+// EachComplex128 calls the specified callback for each object
+// in the []complex128.
+//
+// Panics if the object is the wrong type.
+func (v *Value) EachComplex128(callback func(int, complex128) bool) *Value {
+	for index, val := range v.MustComplex128Slice() {
+		carryon := callback(index, val)
+		if !carryon {
+			break
+		}
+	}
+	return v
+}
+
+// WhereComplex128 uses the specified decider function to select items
+// from the []complex128.  The object contained in the result will contain
+// only the selected items.
+func (v *Value) WhereComplex128(decider func(int, complex128) bool) *Value {
+	var selected []complex128
+	v.EachComplex128(func(index int, val complex128) bool {
+		shouldSelect := decider(index, val)
+		if !shouldSelect {
+			selected = append(selected, val)
+		}
+		return true
+	})
+	return &Value{data: selected}
+}
+
+// GroupComplex128 uses the specified grouper function to group the items
+// keyed by the return of the grouper.  The object contained in the
+// result will contain a map[string][]complex128.
+func (v *Value) GroupComplex128(grouper func(int, complex128) string) *Value {
+	groups := make(map[string][]complex128)
+	v.EachComplex128(func(index int, val complex128) bool {
+		group := grouper(index, val)
+		if _, ok := groups[group]; !ok {
+			groups[group] = make([]complex128, 0)
+		}
+		groups[group] = append(groups[group], val)
+		return true
+	})
+	return &Value{data: groups}
+}
+
+// ReplaceComplex128 uses the specified function to replace each complex128s
+// by iterating each item.  The data in the returned result will be a
+// []complex128 containing the replaced items.
+func (v *Value) ReplaceComplex128(replacer func(int, complex128) complex128) *Value {
+	arr := v.MustComplex128Slice()
+	replaced := make([]complex128, len(arr))
+	v.EachComplex128(func(index int, val complex128) bool {
+		replaced[index] = replacer(index, val)
+		return true
+	})
+	return &Value{data: replaced}
+}
+
+// CollectComplex128 uses the specified collector function to collect a value
+// for each of the complex128s in the slice.  The data returned will be a
+// []interface{}.
+func (v *Value) CollectComplex128(collector func(int, complex128) interface{}) *Value {
+	arr := v.MustComplex128Slice()
+	collected := make([]interface{}, len(arr))
+	v.EachComplex128(func(index int, val complex128) bool {
+		collected[index] = collector(index, val)
+		return true
+	})
+	return &Value{data: collected}
+}

--- a/vendor/github.com/stretchr/objx/value.go
+++ b/vendor/github.com/stretchr/objx/value.go
@@ -1,0 +1,159 @@
+package objx
+
+import (
+	"fmt"
+	"strconv"
+)
+
+// Value provides methods for extracting interface{} data in various
+// types.
+type Value struct {
+	// data contains the raw data being managed by this Value
+	data interface{}
+}
+
+// Data returns the raw data contained by this Value
+func (v *Value) Data() interface{} {
+	return v.data
+}
+
+// String returns the value always as a string
+func (v *Value) String() string {
+	switch {
+	case v.IsNil():
+		return ""
+	case v.IsStr():
+		return v.Str()
+	case v.IsBool():
+		return strconv.FormatBool(v.Bool())
+	case v.IsFloat32():
+		return strconv.FormatFloat(float64(v.Float32()), 'f', -1, 32)
+	case v.IsFloat64():
+		return strconv.FormatFloat(v.Float64(), 'f', -1, 64)
+	case v.IsInt():
+		return strconv.FormatInt(int64(v.Int()), 10)
+	case v.IsInt8():
+		return strconv.FormatInt(int64(v.Int8()), 10)
+	case v.IsInt16():
+		return strconv.FormatInt(int64(v.Int16()), 10)
+	case v.IsInt32():
+		return strconv.FormatInt(int64(v.Int32()), 10)
+	case v.IsInt64():
+		return strconv.FormatInt(v.Int64(), 10)
+	case v.IsUint():
+		return strconv.FormatUint(uint64(v.Uint()), 10)
+	case v.IsUint8():
+		return strconv.FormatUint(uint64(v.Uint8()), 10)
+	case v.IsUint16():
+		return strconv.FormatUint(uint64(v.Uint16()), 10)
+	case v.IsUint32():
+		return strconv.FormatUint(uint64(v.Uint32()), 10)
+	case v.IsUint64():
+		return strconv.FormatUint(v.Uint64(), 10)
+	}
+	return fmt.Sprintf("%#v", v.Data())
+}
+
+// StringSlice returns the value always as a []string
+func (v *Value) StringSlice(optionalDefault ...[]string) []string {
+	switch {
+	case v.IsStrSlice():
+		return v.MustStrSlice()
+	case v.IsBoolSlice():
+		slice := v.MustBoolSlice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatBool(iv)
+		}
+		return vals
+	case v.IsFloat32Slice():
+		slice := v.MustFloat32Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatFloat(float64(iv), 'f', -1, 32)
+		}
+		return vals
+	case v.IsFloat64Slice():
+		slice := v.MustFloat64Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatFloat(iv, 'f', -1, 64)
+		}
+		return vals
+	case v.IsIntSlice():
+		slice := v.MustIntSlice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatInt(int64(iv), 10)
+		}
+		return vals
+	case v.IsInt8Slice():
+		slice := v.MustInt8Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatInt(int64(iv), 10)
+		}
+		return vals
+	case v.IsInt16Slice():
+		slice := v.MustInt16Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatInt(int64(iv), 10)
+		}
+		return vals
+	case v.IsInt32Slice():
+		slice := v.MustInt32Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatInt(int64(iv), 10)
+		}
+		return vals
+	case v.IsInt64Slice():
+		slice := v.MustInt64Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatInt(iv, 10)
+		}
+		return vals
+	case v.IsUintSlice():
+		slice := v.MustUintSlice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatUint(uint64(iv), 10)
+		}
+		return vals
+	case v.IsUint8Slice():
+		slice := v.MustUint8Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatUint(uint64(iv), 10)
+		}
+		return vals
+	case v.IsUint16Slice():
+		slice := v.MustUint16Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatUint(uint64(iv), 10)
+		}
+		return vals
+	case v.IsUint32Slice():
+		slice := v.MustUint32Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatUint(uint64(iv), 10)
+		}
+		return vals
+	case v.IsUint64Slice():
+		slice := v.MustUint64Slice()
+		vals := make([]string, len(slice))
+		for i, iv := range slice {
+			vals[i] = strconv.FormatUint(iv, 10)
+		}
+		return vals
+	}
+	if len(optionalDefault) == 1 {
+		return optionalDefault[0]
+	}
+
+	return []string{}
+}

--- a/vendor/github.com/stretchr/testify/mock/doc.go
+++ b/vendor/github.com/stretchr/testify/mock/doc.go
@@ -1,0 +1,44 @@
+// Package mock provides a system by which it is possible to mock your objects
+// and verify calls are happening as expected.
+//
+// Example Usage
+//
+// The mock package provides an object, Mock, that tracks activity on another object.  It is usually
+// embedded into a test object as shown below:
+//
+//   type MyTestObject struct {
+//     // add a Mock object instance
+//     mock.Mock
+//
+//     // other fields go here as normal
+//   }
+//
+// When implementing the methods of an interface, you wire your functions up
+// to call the Mock.Called(args...) method, and return the appropriate values.
+//
+// For example, to mock a method that saves the name and age of a person and returns
+// the year of their birth or an error, you might write this:
+//
+//     func (o *MyTestObject) SavePersonDetails(firstname, lastname string, age int) (int, error) {
+//       args := o.Called(firstname, lastname, age)
+//       return args.Int(0), args.Error(1)
+//     }
+//
+// The Int, Error and Bool methods are examples of strongly typed getters that take the argument
+// index position. Given this argument list:
+//
+//     (12, true, "Something")
+//
+// You could read them out strongly typed like this:
+//
+//     args.Int(0)
+//     args.Bool(1)
+//     args.String(2)
+//
+// For objects of your own type, use the generic Arguments.Get(index) method and make a type assertion:
+//
+//     return args.Get(0).(*MyObject), args.Get(1).(*AnotherObjectOfMine)
+//
+// This may cause a panic if the object you are getting is nil (the type assertion will fail), in those
+// cases you should check for nil first.
+package mock

--- a/vendor/github.com/stretchr/testify/mock/mock.go
+++ b/vendor/github.com/stretchr/testify/mock/mock.go
@@ -1,0 +1,894 @@
+package mock
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/davecgh/go-spew/spew"
+	"github.com/pmezard/go-difflib/difflib"
+	"github.com/stretchr/objx"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestingT is an interface wrapper around *testing.T
+type TestingT interface {
+	Logf(format string, args ...interface{})
+	Errorf(format string, args ...interface{})
+	FailNow()
+}
+
+/*
+	Call
+*/
+
+// Call represents a method call and is used for setting expectations,
+// as well as recording activity.
+type Call struct {
+	Parent *Mock
+
+	// The name of the method that was or will be called.
+	Method string
+
+	// Holds the arguments of the method.
+	Arguments Arguments
+
+	// Holds the arguments that should be returned when
+	// this method is called.
+	ReturnArguments Arguments
+
+	// Holds the caller info for the On() call
+	callerInfo []string
+
+	// The number of times to return the return arguments when setting
+	// expectations. 0 means to always return the value.
+	Repeatability int
+
+	// Amount of times this call has been called
+	totalCalls int
+
+	// Call to this method can be optional
+	optional bool
+
+	// Holds a channel that will be used to block the Return until it either
+	// receives a message or is closed. nil means it returns immediately.
+	WaitFor <-chan time.Time
+
+	waitTime time.Duration
+
+	// Holds a handler used to manipulate arguments content that are passed by
+	// reference. It's useful when mocking methods such as unmarshalers or
+	// decoders.
+	RunFn func(Arguments)
+}
+
+func newCall(parent *Mock, methodName string, callerInfo []string, methodArguments ...interface{}) *Call {
+	return &Call{
+		Parent:          parent,
+		Method:          methodName,
+		Arguments:       methodArguments,
+		ReturnArguments: make([]interface{}, 0),
+		callerInfo:      callerInfo,
+		Repeatability:   0,
+		WaitFor:         nil,
+		RunFn:           nil,
+	}
+}
+
+func (c *Call) lock() {
+	c.Parent.mutex.Lock()
+}
+
+func (c *Call) unlock() {
+	c.Parent.mutex.Unlock()
+}
+
+// Return specifies the return arguments for the expectation.
+//
+//    Mock.On("DoSomething").Return(errors.New("failed"))
+func (c *Call) Return(returnArguments ...interface{}) *Call {
+	c.lock()
+	defer c.unlock()
+
+	c.ReturnArguments = returnArguments
+
+	return c
+}
+
+// Once indicates that that the mock should only return the value once.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Once()
+func (c *Call) Once() *Call {
+	return c.Times(1)
+}
+
+// Twice indicates that that the mock should only return the value twice.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Twice()
+func (c *Call) Twice() *Call {
+	return c.Times(2)
+}
+
+// Times indicates that that the mock should only return the indicated number
+// of times.
+//
+//    Mock.On("MyMethod", arg1, arg2).Return(returnArg1, returnArg2).Times(5)
+func (c *Call) Times(i int) *Call {
+	c.lock()
+	defer c.unlock()
+	c.Repeatability = i
+	return c
+}
+
+// WaitUntil sets the channel that will block the mock's return until its closed
+// or a message is received.
+//
+//    Mock.On("MyMethod", arg1, arg2).WaitUntil(time.After(time.Second))
+func (c *Call) WaitUntil(w <-chan time.Time) *Call {
+	c.lock()
+	defer c.unlock()
+	c.WaitFor = w
+	return c
+}
+
+// After sets how long to block until the call returns
+//
+//    Mock.On("MyMethod", arg1, arg2).After(time.Second)
+func (c *Call) After(d time.Duration) *Call {
+	c.lock()
+	defer c.unlock()
+	c.waitTime = d
+	return c
+}
+
+// Run sets a handler to be called before returning. It can be used when
+// mocking a method such as unmarshalers that takes a pointer to a struct and
+// sets properties in such struct
+//
+//    Mock.On("Unmarshal", AnythingOfType("*map[string]interface{}").Return().Run(func(args Arguments) {
+//    	arg := args.Get(0).(*map[string]interface{})
+//    	arg["foo"] = "bar"
+//    })
+func (c *Call) Run(fn func(args Arguments)) *Call {
+	c.lock()
+	defer c.unlock()
+	c.RunFn = fn
+	return c
+}
+
+// Maybe allows the method call to be optional. Not calling an optional method
+// will not cause an error while asserting expectations
+func (c *Call) Maybe() *Call {
+	c.lock()
+	defer c.unlock()
+	c.optional = true
+	return c
+}
+
+// On chains a new expectation description onto the mocked interface. This
+// allows syntax like.
+//
+//    Mock.
+//       On("MyMethod", 1).Return(nil).
+//       On("MyOtherMethod", 'a', 'b', 'c').Return(errors.New("Some Error"))
+//go:noinline
+func (c *Call) On(methodName string, arguments ...interface{}) *Call {
+	return c.Parent.On(methodName, arguments...)
+}
+
+// Mock is the workhorse used to track activity on another object.
+// For an example of its usage, refer to the "Example Usage" section at the top
+// of this document.
+type Mock struct {
+	// Represents the calls that are expected of
+	// an object.
+	ExpectedCalls []*Call
+
+	// Holds the calls that were made to this mocked object.
+	Calls []Call
+
+	// test is An optional variable that holds the test struct, to be used when an
+	// invalid mock call was made.
+	test TestingT
+
+	// TestData holds any data that might be useful for testing.  Testify ignores
+	// this data completely allowing you to do whatever you like with it.
+	testData objx.Map
+
+	mutex sync.Mutex
+}
+
+// TestData holds any data that might be useful for testing.  Testify ignores
+// this data completely allowing you to do whatever you like with it.
+func (m *Mock) TestData() objx.Map {
+
+	if m.testData == nil {
+		m.testData = make(objx.Map)
+	}
+
+	return m.testData
+}
+
+/*
+	Setting expectations
+*/
+
+// Test sets the test struct variable of the mock object
+func (m *Mock) Test(t TestingT) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	m.test = t
+}
+
+// fail fails the current test with the given formatted format and args.
+// In case that a test was defined, it uses the test APIs for failing a test,
+// otherwise it uses panic.
+func (m *Mock) fail(format string, args ...interface{}) {
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+
+	if m.test == nil {
+		panic(fmt.Sprintf(format, args...))
+	}
+	m.test.Errorf(format, args...)
+	m.test.FailNow()
+}
+
+// On starts a description of an expectation of the specified method
+// being called.
+//
+//     Mock.On("MyMethod", arg1, arg2)
+func (m *Mock) On(methodName string, arguments ...interface{}) *Call {
+	for _, arg := range arguments {
+		if v := reflect.ValueOf(arg); v.Kind() == reflect.Func {
+			panic(fmt.Sprintf("cannot use Func in expectations. Use mock.AnythingOfType(\"%T\")", arg))
+		}
+	}
+
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	c := newCall(m, methodName, assert.CallerInfo(), arguments...)
+	m.ExpectedCalls = append(m.ExpectedCalls, c)
+	return c
+}
+
+// /*
+// 	Recording and responding to activity
+// */
+
+func (m *Mock) findExpectedCall(method string, arguments ...interface{}) (int, *Call) {
+	var expectedCall *Call
+
+	for i, call := range m.ExpectedCalls {
+		if call.Method == method {
+			_, diffCount := call.Arguments.Diff(arguments)
+			if diffCount == 0 {
+				expectedCall = call
+				if call.Repeatability > -1 {
+					return i, call
+				}
+			}
+		}
+	}
+
+	return -1, expectedCall
+}
+
+func (m *Mock) findClosestCall(method string, arguments ...interface{}) (*Call, string) {
+	var diffCount int
+	var closestCall *Call
+	var err string
+
+	for _, call := range m.expectedCalls() {
+		if call.Method == method {
+
+			errInfo, tempDiffCount := call.Arguments.Diff(arguments)
+			if tempDiffCount < diffCount || diffCount == 0 {
+				diffCount = tempDiffCount
+				closestCall = call
+				err = errInfo
+			}
+
+		}
+	}
+
+	return closestCall, err
+}
+
+func callString(method string, arguments Arguments, includeArgumentValues bool) string {
+
+	var argValsString string
+	if includeArgumentValues {
+		var argVals []string
+		for argIndex, arg := range arguments {
+			argVals = append(argVals, fmt.Sprintf("%d: %#v", argIndex, arg))
+		}
+		argValsString = fmt.Sprintf("\n\t\t%s", strings.Join(argVals, "\n\t\t"))
+	}
+
+	return fmt.Sprintf("%s(%s)%s", method, arguments.String(), argValsString)
+}
+
+// Called tells the mock object that a method has been called, and gets an array
+// of arguments to return.  Panics if the call is unexpected (i.e. not preceded by
+// appropriate .On .Return() calls)
+// If Call.WaitFor is set, blocks until the channel is closed or receives a message.
+func (m *Mock) Called(arguments ...interface{}) Arguments {
+	// get the calling function's name
+	pc, _, _, ok := runtime.Caller(1)
+	if !ok {
+		panic("Couldn't get the caller information")
+	}
+	functionPath := runtime.FuncForPC(pc).Name()
+	//Next four lines are required to use GCCGO function naming conventions.
+	//For Ex:  github_com_docker_libkv_store_mock.WatchTree.pN39_github_com_docker_libkv_store_mock.Mock
+	//uses interface information unlike golang github.com/docker/libkv/store/mock.(*Mock).WatchTree
+	//With GCCGO we need to remove interface information starting from pN<dd>.
+	re := regexp.MustCompile("\\.pN\\d+_")
+	if re.MatchString(functionPath) {
+		functionPath = re.Split(functionPath, -1)[0]
+	}
+	parts := strings.Split(functionPath, ".")
+	functionName := parts[len(parts)-1]
+	return m.MethodCalled(functionName, arguments...)
+}
+
+// MethodCalled tells the mock object that the given method has been called, and gets
+// an array of arguments to return. Panics if the call is unexpected (i.e. not preceded
+// by appropriate .On .Return() calls)
+// If Call.WaitFor is set, blocks until the channel is closed or receives a message.
+func (m *Mock) MethodCalled(methodName string, arguments ...interface{}) Arguments {
+	m.mutex.Lock()
+	//TODO: could combine expected and closes in single loop
+	found, call := m.findExpectedCall(methodName, arguments...)
+
+	if found < 0 {
+		// expected call found but it has already been called with repeatable times
+		if call != nil {
+			m.mutex.Unlock()
+			m.fail("\nassert: mock: The method has been called over %d times.\n\tEither do one more Mock.On(\"%s\").Return(...), or remove extra call.\n\tThis call was unexpected:\n\t\t%s\n\tat: %s", call.totalCalls, methodName, callString(methodName, arguments, true), assert.CallerInfo())
+		}
+		// we have to fail here - because we don't know what to do
+		// as the return arguments.  This is because:
+		//
+		//   a) this is a totally unexpected call to this method,
+		//   b) the arguments are not what was expected, or
+		//   c) the developer has forgotten to add an accompanying On...Return pair.
+		closestCall, mismatch := m.findClosestCall(methodName, arguments...)
+		m.mutex.Unlock()
+
+		if closestCall != nil {
+			m.fail("\n\nmock: Unexpected Method Call\n-----------------------------\n\n%s\n\nThe closest call I have is: \n\n%s\n\n%s\nDiff: %s",
+				callString(methodName, arguments, true),
+				callString(methodName, closestCall.Arguments, true),
+				diffArguments(closestCall.Arguments, arguments),
+				strings.TrimSpace(mismatch),
+			)
+		} else {
+			m.fail("\nassert: mock: I don't know what to return because the method call was unexpected.\n\tEither do Mock.On(\"%s\").Return(...) first, or remove the %s() call.\n\tThis method was unexpected:\n\t\t%s\n\tat: %s", methodName, methodName, callString(methodName, arguments, true), assert.CallerInfo())
+		}
+	}
+
+	if call.Repeatability == 1 {
+		call.Repeatability = -1
+	} else if call.Repeatability > 1 {
+		call.Repeatability--
+	}
+	call.totalCalls++
+
+	// add the call
+	m.Calls = append(m.Calls, *newCall(m, methodName, assert.CallerInfo(), arguments...))
+	m.mutex.Unlock()
+
+	// block if specified
+	if call.WaitFor != nil {
+		<-call.WaitFor
+	} else {
+		time.Sleep(call.waitTime)
+	}
+
+	m.mutex.Lock()
+	runFn := call.RunFn
+	m.mutex.Unlock()
+
+	if runFn != nil {
+		runFn(arguments)
+	}
+
+	m.mutex.Lock()
+	returnArgs := call.ReturnArguments
+	m.mutex.Unlock()
+
+	return returnArgs
+}
+
+/*
+	Assertions
+*/
+
+type assertExpectationser interface {
+	AssertExpectations(TestingT) bool
+}
+
+// AssertExpectationsForObjects asserts that everything specified with On and Return
+// of the specified objects was in fact called as expected.
+//
+// Calls may have occurred in any order.
+func AssertExpectationsForObjects(t TestingT, testObjects ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	for _, obj := range testObjects {
+		if m, ok := obj.(Mock); ok {
+			t.Logf("Deprecated mock.AssertExpectationsForObjects(myMock.Mock) use mock.AssertExpectationsForObjects(myMock)")
+			obj = &m
+		}
+		m := obj.(assertExpectationser)
+		if !m.AssertExpectations(t) {
+			t.Logf("Expectations didn't match for Mock: %+v", reflect.TypeOf(m))
+			return false
+		}
+	}
+	return true
+}
+
+// AssertExpectations asserts that everything specified with On and Return was
+// in fact called as expected.  Calls may have occurred in any order.
+func (m *Mock) AssertExpectations(t TestingT) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var somethingMissing bool
+	var failedExpectations int
+
+	// iterate through each expectation
+	expectedCalls := m.expectedCalls()
+	for _, expectedCall := range expectedCalls {
+		if !expectedCall.optional && !m.methodWasCalled(expectedCall.Method, expectedCall.Arguments) && expectedCall.totalCalls == 0 {
+			somethingMissing = true
+			failedExpectations++
+			t.Logf("FAIL:\t%s(%s)\n\t\tat: %s", expectedCall.Method, expectedCall.Arguments.String(), expectedCall.callerInfo)
+		} else {
+			if expectedCall.Repeatability > 0 {
+				somethingMissing = true
+				failedExpectations++
+				t.Logf("FAIL:\t%s(%s)\n\t\tat: %s", expectedCall.Method, expectedCall.Arguments.String(), expectedCall.callerInfo)
+			} else {
+				t.Logf("PASS:\t%s(%s)", expectedCall.Method, expectedCall.Arguments.String())
+			}
+		}
+	}
+
+	if somethingMissing {
+		t.Errorf("FAIL: %d out of %d expectation(s) were met.\n\tThe code you are testing needs to make %d more call(s).\n\tat: %s", len(expectedCalls)-failedExpectations, len(expectedCalls), failedExpectations, assert.CallerInfo())
+	}
+
+	return !somethingMissing
+}
+
+// AssertNumberOfCalls asserts that the method was called expectedCalls times.
+func (m *Mock) AssertNumberOfCalls(t TestingT, methodName string, expectedCalls int) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	var actualCalls int
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+			actualCalls++
+		}
+	}
+	return assert.Equal(t, expectedCalls, actualCalls, fmt.Sprintf("Expected number of calls (%d) does not match the actual number of calls (%d).", expectedCalls, actualCalls))
+}
+
+// AssertCalled asserts that the method was called.
+// It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
+func (m *Mock) AssertCalled(t TestingT, methodName string, arguments ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if !m.methodWasCalled(methodName, arguments) {
+		var calledWithArgs []string
+		for _, call := range m.calls() {
+			calledWithArgs = append(calledWithArgs, fmt.Sprintf("%v", call.Arguments))
+		}
+		if len(calledWithArgs) == 0 {
+			return assert.Fail(t, "Should have called with given arguments",
+				fmt.Sprintf("Expected %q to have been called with:\n%v\nbut no actual calls happened", methodName, arguments))
+		}
+		return assert.Fail(t, "Should have called with given arguments",
+			fmt.Sprintf("Expected %q to have been called with:\n%v\nbut actual calls were:\n        %v", methodName, arguments, strings.Join(calledWithArgs, "\n")))
+	}
+	return true
+}
+
+// AssertNotCalled asserts that the method was not called.
+// It can produce a false result when an argument is a pointer type and the underlying value changed after calling the mocked method.
+func (m *Mock) AssertNotCalled(t TestingT, methodName string, arguments ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+	m.mutex.Lock()
+	defer m.mutex.Unlock()
+	if m.methodWasCalled(methodName, arguments) {
+		return assert.Fail(t, "Should not have called with given arguments",
+			fmt.Sprintf("Expected %q to not have been called with:\n%v\nbut actually it was.", methodName, arguments))
+	}
+	return true
+}
+
+func (m *Mock) methodWasCalled(methodName string, expected []interface{}) bool {
+	for _, call := range m.calls() {
+		if call.Method == methodName {
+
+			_, differences := Arguments(expected).Diff(call.Arguments)
+
+			if differences == 0 {
+				// found the expected call
+				return true
+			}
+
+		}
+	}
+	// we didn't find the expected call
+	return false
+}
+
+func (m *Mock) expectedCalls() []*Call {
+	return append([]*Call{}, m.ExpectedCalls...)
+}
+
+func (m *Mock) calls() []Call {
+	return append([]Call{}, m.Calls...)
+}
+
+/*
+	Arguments
+*/
+
+// Arguments holds an array of method arguments or return values.
+type Arguments []interface{}
+
+const (
+	// Anything is used in Diff and Assert when the argument being tested
+	// shouldn't be taken into consideration.
+	Anything = "mock.Anything"
+)
+
+// AnythingOfTypeArgument is a string that contains the type of an argument
+// for use when type checking.  Used in Diff and Assert.
+type AnythingOfTypeArgument string
+
+// AnythingOfType returns an AnythingOfTypeArgument object containing the
+// name of the type to check for.  Used in Diff and Assert.
+//
+// For example:
+//	Assert(t, AnythingOfType("string"), AnythingOfType("int"))
+func AnythingOfType(t string) AnythingOfTypeArgument {
+	return AnythingOfTypeArgument(t)
+}
+
+// argumentMatcher performs custom argument matching, returning whether or
+// not the argument is matched by the expectation fixture function.
+type argumentMatcher struct {
+	// fn is a function which accepts one argument, and returns a bool.
+	fn reflect.Value
+}
+
+func (f argumentMatcher) Matches(argument interface{}) bool {
+	expectType := f.fn.Type().In(0)
+	expectTypeNilSupported := false
+	switch expectType.Kind() {
+	case reflect.Interface, reflect.Chan, reflect.Func, reflect.Map, reflect.Slice, reflect.Ptr:
+		expectTypeNilSupported = true
+	}
+
+	argType := reflect.TypeOf(argument)
+	var arg reflect.Value
+	if argType == nil {
+		arg = reflect.New(expectType).Elem()
+	} else {
+		arg = reflect.ValueOf(argument)
+	}
+
+	if argType == nil && !expectTypeNilSupported {
+		panic(errors.New("attempting to call matcher with nil for non-nil expected type"))
+	}
+	if argType == nil || argType.AssignableTo(expectType) {
+		result := f.fn.Call([]reflect.Value{arg})
+		return result[0].Bool()
+	}
+	return false
+}
+
+func (f argumentMatcher) String() string {
+	return fmt.Sprintf("func(%s) bool", f.fn.Type().In(0).Name())
+}
+
+// MatchedBy can be used to match a mock call based on only certain properties
+// from a complex struct or some calculation. It takes a function that will be
+// evaluated with the called argument and will return true when there's a match
+// and false otherwise.
+//
+// Example:
+// m.On("Do", MatchedBy(func(req *http.Request) bool { return req.Host == "example.com" }))
+//
+// |fn|, must be a function accepting a single argument (of the expected type)
+// which returns a bool. If |fn| doesn't match the required signature,
+// MatchedBy() panics.
+func MatchedBy(fn interface{}) argumentMatcher {
+	fnType := reflect.TypeOf(fn)
+
+	if fnType.Kind() != reflect.Func {
+		panic(fmt.Sprintf("assert: arguments: %s is not a func", fn))
+	}
+	if fnType.NumIn() != 1 {
+		panic(fmt.Sprintf("assert: arguments: %s does not take exactly one argument", fn))
+	}
+	if fnType.NumOut() != 1 || fnType.Out(0).Kind() != reflect.Bool {
+		panic(fmt.Sprintf("assert: arguments: %s does not return a bool", fn))
+	}
+
+	return argumentMatcher{fn: reflect.ValueOf(fn)}
+}
+
+// Get Returns the argument at the specified index.
+func (args Arguments) Get(index int) interface{} {
+	if index+1 > len(args) {
+		panic(fmt.Sprintf("assert: arguments: Cannot call Get(%d) because there are %d argument(s).", index, len(args)))
+	}
+	return args[index]
+}
+
+// Is gets whether the objects match the arguments specified.
+func (args Arguments) Is(objects ...interface{}) bool {
+	for i, obj := range args {
+		if obj != objects[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// Diff gets a string describing the differences between the arguments
+// and the specified objects.
+//
+// Returns the diff string and number of differences found.
+func (args Arguments) Diff(objects []interface{}) (string, int) {
+	//TODO: could return string as error and nil for No difference
+
+	var output = "\n"
+	var differences int
+
+	var maxArgCount = len(args)
+	if len(objects) > maxArgCount {
+		maxArgCount = len(objects)
+	}
+
+	for i := 0; i < maxArgCount; i++ {
+		var actual, expected interface{}
+		var actualFmt, expectedFmt string
+
+		if len(objects) <= i {
+			actual = "(Missing)"
+			actualFmt = "(Missing)"
+		} else {
+			actual = objects[i]
+			actualFmt = fmt.Sprintf("(%[1]T=%[1]v)", actual)
+		}
+
+		if len(args) <= i {
+			expected = "(Missing)"
+			expectedFmt = "(Missing)"
+		} else {
+			expected = args[i]
+			expectedFmt = fmt.Sprintf("(%[1]T=%[1]v)", expected)
+		}
+
+		if matcher, ok := expected.(argumentMatcher); ok {
+			if matcher.Matches(actual) {
+				output = fmt.Sprintf("%s\t%d: PASS:  %s matched by %s\n", output, i, actualFmt, matcher)
+			} else {
+				differences++
+				output = fmt.Sprintf("%s\t%d: FAIL:  %s not matched by %s\n", output, i, actualFmt, matcher)
+			}
+		} else if reflect.TypeOf(expected) == reflect.TypeOf((*AnythingOfTypeArgument)(nil)).Elem() {
+
+			// type checking
+			if reflect.TypeOf(actual).Name() != string(expected.(AnythingOfTypeArgument)) && reflect.TypeOf(actual).String() != string(expected.(AnythingOfTypeArgument)) {
+				// not match
+				differences++
+				output = fmt.Sprintf("%s\t%d: FAIL:  type %s != type %s - %s\n", output, i, expected, reflect.TypeOf(actual).Name(), actualFmt)
+			}
+
+		} else {
+
+			// normal checking
+
+			if assert.ObjectsAreEqual(expected, Anything) || assert.ObjectsAreEqual(actual, Anything) || assert.ObjectsAreEqual(actual, expected) {
+				// match
+				output = fmt.Sprintf("%s\t%d: PASS:  %s == %s\n", output, i, actualFmt, expectedFmt)
+			} else {
+				// not match
+				differences++
+				output = fmt.Sprintf("%s\t%d: FAIL:  %s != %s\n", output, i, actualFmt, expectedFmt)
+			}
+		}
+
+	}
+
+	if differences == 0 {
+		return "No differences.", differences
+	}
+
+	return output, differences
+
+}
+
+// Assert compares the arguments with the specified objects and fails if
+// they do not exactly match.
+func (args Arguments) Assert(t TestingT, objects ...interface{}) bool {
+	if h, ok := t.(tHelper); ok {
+		h.Helper()
+	}
+
+	// get the differences
+	diff, diffCount := args.Diff(objects)
+
+	if diffCount == 0 {
+		return true
+	}
+
+	// there are differences... report them...
+	t.Logf(diff)
+	t.Errorf("%sArguments do not match.", assert.CallerInfo())
+
+	return false
+
+}
+
+// String gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+//
+// If no index is provided, String() returns a complete string representation
+// of the arguments.
+func (args Arguments) String(indexOrNil ...int) string {
+
+	if len(indexOrNil) == 0 {
+		// normal String() method - return a string representation of the args
+		var argsStr []string
+		for _, arg := range args {
+			argsStr = append(argsStr, fmt.Sprintf("%s", reflect.TypeOf(arg)))
+		}
+		return strings.Join(argsStr, ",")
+	} else if len(indexOrNil) == 1 {
+		// Index has been specified - get the argument at that index
+		var index = indexOrNil[0]
+		var s string
+		var ok bool
+		if s, ok = args.Get(index).(string); !ok {
+			panic(fmt.Sprintf("assert: arguments: String(%d) failed because object wasn't correct type: %s", index, args.Get(index)))
+		}
+		return s
+	}
+
+	panic(fmt.Sprintf("assert: arguments: Wrong number of arguments passed to String.  Must be 0 or 1, not %d", len(indexOrNil)))
+
+}
+
+// Int gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Int(index int) int {
+	var s int
+	var ok bool
+	if s, ok = args.Get(index).(int); !ok {
+		panic(fmt.Sprintf("assert: arguments: Int(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
+	}
+	return s
+}
+
+// Error gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Error(index int) error {
+	obj := args.Get(index)
+	var s error
+	var ok bool
+	if obj == nil {
+		return nil
+	}
+	if s, ok = obj.(error); !ok {
+		panic(fmt.Sprintf("assert: arguments: Error(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
+	}
+	return s
+}
+
+// Bool gets the argument at the specified index. Panics if there is no argument, or
+// if the argument is of the wrong type.
+func (args Arguments) Bool(index int) bool {
+	var s bool
+	var ok bool
+	if s, ok = args.Get(index).(bool); !ok {
+		panic(fmt.Sprintf("assert: arguments: Bool(%d) failed because object wasn't correct type: %v", index, args.Get(index)))
+	}
+	return s
+}
+
+func typeAndKind(v interface{}) (reflect.Type, reflect.Kind) {
+	t := reflect.TypeOf(v)
+	k := t.Kind()
+
+	if k == reflect.Ptr {
+		t = t.Elem()
+		k = t.Kind()
+	}
+	return t, k
+}
+
+func diffArguments(expected Arguments, actual Arguments) string {
+	if len(expected) != len(actual) {
+		return fmt.Sprintf("Provided %v arguments, mocked for %v arguments", len(expected), len(actual))
+	}
+
+	for x := range expected {
+		if diffString := diff(expected[x], actual[x]); diffString != "" {
+			return fmt.Sprintf("Difference found in argument %v:\n\n%s", x, diffString)
+		}
+	}
+
+	return ""
+}
+
+// diff returns a diff of both values as long as both are of the same type and
+// are a struct, map, slice or array. Otherwise it returns an empty string.
+func diff(expected interface{}, actual interface{}) string {
+	if expected == nil || actual == nil {
+		return ""
+	}
+
+	et, ek := typeAndKind(expected)
+	at, _ := typeAndKind(actual)
+
+	if et != at {
+		return ""
+	}
+
+	if ek != reflect.Struct && ek != reflect.Map && ek != reflect.Slice && ek != reflect.Array {
+		return ""
+	}
+
+	e := spewConfig.Sdump(expected)
+	a := spewConfig.Sdump(actual)
+
+	diff, _ := difflib.GetUnifiedDiffString(difflib.UnifiedDiff{
+		A:        difflib.SplitLines(e),
+		B:        difflib.SplitLines(a),
+		FromFile: "Expected",
+		FromDate: "",
+		ToFile:   "Actual",
+		ToDate:   "",
+		Context:  1,
+	})
+
+	return diff
+}
+
+var spewConfig = spew.ConfigState{
+	Indent:                  " ",
+	DisablePointerAddresses: true,
+	DisableCapacities:       true,
+	SortKeys:                true,
+}
+
+type tHelper interface {
+	Helper()
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -292,10 +292,22 @@
 			"revisionTime": "2019-11-08T00:09:09Z"
 		},
 		{
+			"checksumSHA1": "tLHFmMOC2eMcXYaPXfifUVj3wX4=",
+			"path": "github.com/stretchr/objx",
+			"revision": "35313a95ee26395aa17d366c71a2ccf788fa69b6",
+			"revisionTime": "2019-04-15T11:18:23Z"
+		},
+		{
 			"checksumSHA1": "9O575nDCni6OBuppl7Wo4qxI4Xs=",
 			"path": "github.com/stretchr/testify/assert",
 			"revision": "f1bd0923b8320ddfb0a8a9d919b5aeb8b7a4cc40",
 			"revisionTime": "2019-08-29T23:36:06Z"
+		},
+		{
+			"checksumSHA1": "bg70xAHEu6HRf2iFu8h5iJBjUfg=",
+			"path": "github.com/stretchr/testify/mock",
+			"revision": "85f2b59c4459e5bf57488796be8c3667cb8246d6",
+			"revisionTime": "2018-07-16T14:42:29Z"
 		},
 		{
 			"checksumSHA1": "MZ4JU44HUXZ4JB+oxYrw9wpaOZU=",


### PR DESCRIPTION
store: Rework mock and improve error handling
A proper mock is added to the data store mock, and some of the arguments
to the data store interface was extended with a context argument where
necessary.
The channel from the job scheduler is made generic (interface{}) such
that the main worker routine is notified when an error occurs.

worker: Improve error handling and refactoring task definitions
Setting the scene for implementing different task types by creating a
top level Task construct along with an interface.
For the worker, the context is now used to cancel the scheduler and
workers in progress.