### PR TITLE
Re-create the Pipeline based on the new mendertesting templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,112 +1,45 @@
-image: golang:1.13
-
-cache:
-  paths:
-    - /apt-cache
-    - /go/src/github.com
-    - /go/src/golang.org
-    - /go/src/gopkg.in
-    - node_modules
-
 stages:
   - test
   - build
   - publish
 
+include:
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-golang-static.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-golang-unittests.yml'
+  - project: 'Northern.tech/Mender/mendertesting'
+    file: '.gitlab-ci-check-apidocs.yml'
+
 before_script:
-  - export DOCKER_REPOSITORY="mendersoftware/workflows"
+  - export DOCKER_REPOSITORY="mendersoftware/${CI_PROJECT_NAME}"
   - export DOCKER_TAG=${CI_COMMIT_REF_SLUG:-master}
   - export SERVICE_IMAGE=$DOCKER_REPOSITORY:$DOCKER_TAG
   - export COMMIT_TAG="$CI_COMMIT_REF_SLUG"_"$CI_COMMIT_SHA"
 
-test:static:
-  stage: test
-  script:
-    # Install cyclomatic dependency analysis tool
-    - go get -u github.com/fzipp/gocyclo
-    - curl -sL https://deb.nodesource.com/setup_11.x | bash -
-    - apt-get -qq update
-    - apt-get install -qy --allow-unauthenticated python3-pip nodejs
-    - pip3 install pyyaml
-    - npm install -g swagger-cli
-    # Get our own Swagger verifier
-    - wget https://raw.githubusercontent.com/mendersoftware/autodocs/master/verify_docs.py
-    - mkdir -p /go/src/github.com/mendersoftware /go/src/_/builds
-    - cp -r $CI_PROJECT_DIR /go/src/github.com/mendersoftware/workflows
-    - ln -s /go/src/github.com/mendersoftware /go/src/_/builds/mendersoftware
-    - cd /go/src/github.com/mendersoftware/workflows
-    # Test if code was formatted with 'go fmt'
-    # Command will format code and return modified files
-    # fail if any have been modified.
-    - if [ -n "$(go fmt)" ]; then echo 'Code is not formatted with "go fmt"'; false; fi
-    # Perform static code analysys
-    - go vet `go list ./... | grep -v vendor`
-    # Fail builds when the cyclomatic complexity reaches 20 or more
-    - gocyclo -over 20 `find . -iname '*.go' | grep -v 'vendor' | grep -v '_test.go'`
-    # Verify that the Swagger docs are valid
-    - swagger-cli validate docs/*.yml
-    # Verify that the Swagger docs follow the autodeployment requirements
-    - python3 verify_docs.py `find docs -name "*.yml"`
-
-test:unit:
-  stage: test
-  script:
-    # Install code coverage tooling
-    - go get -u github.com/axw/gocov/gocov
-    - go get -u golang.org/x/tools/cmd/cover
-
-    # Rename the branch we're on, so that it's not in the way for the
-    # subsequent fetch. It's ok if this fails, it just means we're not on any
-    # branch.
-    - git branch -m temp-branch || true
-    # Git trick: Fetch directly into our local branches instead of remote
-    # branches.
-    - git fetch origin 'refs/heads/*:refs/heads/*'
-    # Get last remaining tags, if any.
-    - git fetch --tags origin
-
-    - mkdir -p /go/src/github.com/mendersoftware /go/src/_/builds
-    - cp -r $CI_PROJECT_DIR /go/src/github.com/mendersoftware/workflows
-    - ln -s /go/src/github.com/mendersoftware /go/src/_/builds/mendersoftware
-    - cd /go/src/github.com/mendersoftware/workflows
-    - go list ./... | grep -v vendor | xargs -n1 -I {} -P 4 go test -v -covermode=atomic -coverprofile=../../../{}/coverage.txt {} || exit $? ;
-    - mkdir -p tests/unit-coverage && find . -name 'coverage.txt' -exec cp --parents {} ./tests/unit-coverage \;
-    - tar -cvf $CI_PROJECT_DIR/unit-coverage.tar tests/unit-coverage
-  artifacts:
-    expire_in: 2w
-    paths:
-      - unit-coverage.tar
-
 build:
-  image: docker
   stage: build
+  tags:
+    - docker
+  image: docker
   services:
     - docker:dind
   script:
-    - echo "building workflows for ${SERVICE_IMAGE}"
+    - echo "building ${CI_PROJECT_NAME} for ${SERVICE_IMAGE}"
     - docker build -t $SERVICE_IMAGE .
     - docker save $SERVICE_IMAGE > image.tar
   artifacts:
     expire_in: 2w
     paths:
       - image.tar
+
+publish:image:
+  stage: publish
+  only:
+    - /^(master|[0-9]+\.[0-9]+\.x)$/
   tags:
     - docker
-
-publish:tests:
-  image: alpine
-  stage: publish
-  before_script:
-    - apk add --no-cache bash curl findutils git
-  dependencies:
-    - test:unit
-  script:
-    - tar -xvf unit-coverage.tar
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -s ./tests/unit-coverage"
-
-publish:build:
   image: docker
-  stage: publish
   services:
     - docker:dind
   dependencies:
@@ -118,7 +51,3 @@ publish:build:
     - echo -n $DOCKER_HUB_PASSWORD | docker login -u $DOCKER_HUB_USERNAME --password-stdin
     - docker push $DOCKER_REPOSITORY:$COMMIT_TAG
     - docker push $SERVICE_IMAGE
-  only:
-    - /^(master|[0-9]+\.[0-9]+\.x)$/
-  tags:
-    - docker

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2019 Northern.tech AS
+Copyright 2020 Northern.tech AS
 
 All content in this project is licensed under the Apache License v2, unless
 indicated otherwise.

--- a/LIC_FILES_CHKSUM.sha256
+++ b/LIC_FILES_CHKSUM.sha256
@@ -1,6 +1,6 @@
 #
 # These are identical to Apache-2.0 license.
-beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  LICENSE
+32714818ad6f98ee0185a52e23a475d89122e3efd2b2c26c733781c28e798c99  LICENSE
 beb140be4cd64599bedc691a55b2729c9cc611a4b9d6ec44e01270105daf18a2  vendor/github.com/mendersoftware/mendertesting/LICENSE
 c1452ea0feb52f2e6e6aaba33ae0d558626ba8c69ad7cb6866f2d4fbb7a711dc  vendor/github.com/mendersoftware/go-lib-micro/LICENSE
 5e3400b93bbb099e83e52bab885e7441750673c21f97988ca3f1240639b63283  vendor/github.com/spf13/afero/LICENSE.txt


### PR DESCRIPTION
This PR depends on https://github.com/mendersoftware/mendertesting/pull/36 being approved/merged.

An smoke run on how it will look can be found in [Pipeline 104890658](https://gitlab.com/Northern.tech/Mender/workflows/pipelines/104890658).

These templates cover the exact same functionality. The idea is for this
repo to only need to specify custom checks (for example acceptance tests).