### PR TITLE
Improve error handling of HTTP tasks

### DIFF
--- a/api/http/router.go
+++ b/api/http/router.go
@@ -19,13 +19,14 @@ import (
 	"github.com/mendersoftware/workflows/store"
 )
 
+// API URL used by the HTTP router
 const (
-	ApiUrlStatus = "/status"
+	APIURLStatus = "/status"
 
-	ApiUrlWorkflow   = "/api/v1/workflow/:name"
-	ApiUrlWorkflowId = "/api/v1/workflow/:name/:id"
+	APIURLWorkflow   = "/api/v1/workflow/:name"
+	APIURLWorkflowID = "/api/v1/workflow/:name/:id"
 
-	ApiUrlWorkflows = "/api/v1/metadata/workflows"
+	APIURLWorkflows = "/api/v1/metadata/workflows"
 )
 
 // NewRouter returns the gin router
@@ -36,14 +37,14 @@ func NewRouter(dataStore store.DataStore) *gin.Engine {
 	router.Use(gin.Recovery())
 
 	status := NewStatusController()
-	router.GET(ApiUrlStatus, status.Status)
+	router.GET(APIURLStatus, status.Status)
 
 	workflow := NewWorkflowController(dataStore)
-	router.POST(ApiUrlWorkflow, workflow.StartWorkflow)
-	router.GET(ApiUrlWorkflowId, workflow.GetWorkflowByNameAndID)
+	router.POST(APIURLWorkflow, workflow.StartWorkflow)
+	router.GET(APIURLWorkflowID, workflow.GetWorkflowByNameAndID)
 
-	router.POST(ApiUrlWorkflows, workflow.RegisterWorkflow)
-	router.GET(ApiUrlWorkflows, workflow.GetWorkflows)
+	router.POST(APIURLWorkflows, workflow.RegisterWorkflow)
+	router.GET(APIURLWorkflows, workflow.GetWorkflows)
 
 	return router
 }

--- a/api/http/status_test.go
+++ b/api/http/status_test.go
@@ -31,7 +31,7 @@ func TestStatus(t *testing.T) {
 	req, _ := http.NewRequest("GET", "/status", nil)
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, 200, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
 
 	var response map[string]string
 	err := json.Unmarshal([]byte(w.Body.String()), &response)

--- a/api/http/workflow.go
+++ b/api/http/workflow.go
@@ -39,6 +39,7 @@ func NewWorkflowController(dataStore store.DataStore) *WorkflowController {
 	}
 }
 
+// RegisterWorkflow responds to POST /api/v1/metadata/workflows
 func (h WorkflowController) RegisterWorkflow(c *gin.Context) {
 	var workflow model.Workflow
 	rawData, err := c.GetRawData()
@@ -71,6 +72,7 @@ func (h WorkflowController) RegisterWorkflow(c *gin.Context) {
 	c.Status(http.StatusCreated)
 }
 
+// GetWorkflows responds to GET /api/v1/metadata/workflows
 func (h WorkflowController) GetWorkflows(c *gin.Context) {
 	c.JSON(http.StatusOK, h.dataStore.GetWorkflows())
 }

--- a/api/http/workflow_test.go
+++ b/api/http/workflow_test.go
@@ -16,6 +16,7 @@ package http
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -40,7 +41,7 @@ func TestWorkflowNotFound(t *testing.T) {
 	req, _ := http.NewRequest("POST", "/api/v1/workflow/test", strings.NewReader(payload))
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, 404, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestWorkflowFoundButMissingParameters(t *testing.T) {
@@ -68,7 +69,7 @@ func TestWorkflowFoundButMissingParameters(t *testing.T) {
 	assert.NoError(t, err)
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, 400, w.Code)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
 
 	var response map[string]string
 	body := w.Body.Bytes()
@@ -84,7 +85,41 @@ func TestWorkflowFoundButMissingParameters(t *testing.T) {
 	assert.Equal(t, expectedBody["error"], value)
 }
 
-func TestWorkflowFoundAndLaunchedWithParameters(t *testing.T) {
+func TestWorkflowFoundAndStartedWithInvalidParameters(t *testing.T) {
+	dataStore := store.NewDataStoreMock()
+	router := NewRouter(dataStore)
+
+	w := httptest.NewRecorder()
+	workflow := model.Workflow{
+		Name: "test",
+		InputParameters: []string{
+			"key",
+		},
+	}
+	_, err := dataStore.InsertWorkflows(workflow)
+	assert.NoError(t, err)
+
+	payload := ``
+
+	req, _ := http.NewRequest("POST", "/api/v1/workflow/test", strings.NewReader(payload))
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	var response map[string]string
+	body := w.Body.Bytes()
+	err = json.Unmarshal(body, &response)
+	value, ok := response["error"]
+
+	assert.Nil(t, err)
+	assert.True(t, ok)
+
+	expectedBody := gin.H{
+		"error": "Unable to parse the input parameters: EOF",
+	}
+	assert.Equal(t, expectedBody["error"], value)
+}
+
+func TestWorkflowFoundAndStartedWithParameters(t *testing.T) {
 	dataStore := store.NewDataStoreMock()
 	router := NewRouter(dataStore)
 
@@ -105,6 +140,180 @@ func TestWorkflowFoundAndLaunchedWithParameters(t *testing.T) {
 	req, _ := http.NewRequest("POST", "/api/v1/workflow/test", strings.NewReader(payload))
 	router.ServeHTTP(w, req)
 
-	assert.Equal(t, 201, w.Code)
+	assert.Equal(t, http.StatusCreated, w.Code)
 	assert.Equal(t, 1, len(dataStore.Jobs))
+
+	var response map[string]string
+	body := w.Body.Bytes()
+	err = json.Unmarshal(body, &response)
+	value, ok := response["id"]
+	assert.True(t, ok)
+
+	w = httptest.NewRecorder()
+	req, _ = http.NewRequest("GET", fmt.Sprintf("/api/v1/workflow/test/%s", value), nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var job model.Job
+	body = w.Body.Bytes()
+	err = json.Unmarshal(body, &job)
+
+	assert.Nil(t, err)
+	assert.Equal(t, "test", job.WorkflowName)
+	assert.Equal(t, 0, job.Status)
+}
+
+func TestWorkflowByNameAndIDNotFound(t *testing.T) {
+	dataStore := store.NewDataStoreMock()
+	router := NewRouter(dataStore)
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/api/v1/workflow/test/dummy", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestRegisterWorkflowBadRequestIncompletePayload(t *testing.T) {
+	dataStore := store.NewDataStoreMock()
+	router := NewRouter(dataStore)
+
+	w := httptest.NewRecorder()
+
+	payload := ``
+	req, err := http.NewRequest("POST", "/api/v1/metadata/workflows", strings.NewReader(payload))
+	assert.NoError(t, err)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	body := w.Body.Bytes()
+	err = json.Unmarshal(body, &response)
+	value, ok := response["error"]
+
+	assert.Nil(t, err)
+	assert.True(t, ok)
+
+	expectedBody := gin.H{
+		"error": "Error parsing JSON form: unexpected end of JSON input",
+	}
+	assert.Equal(t, expectedBody["error"], value)
+}
+
+func TestRegisterWorkflowBadRequestMissingName(t *testing.T) {
+	dataStore := store.NewDataStoreMock()
+	router := NewRouter(dataStore)
+
+	w := httptest.NewRecorder()
+
+	payload := `{}`
+	req, err := http.NewRequest("POST", "/api/v1/metadata/workflows", strings.NewReader(payload))
+	assert.NoError(t, err)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var response map[string]string
+	body := w.Body.Bytes()
+	err = json.Unmarshal(body, &response)
+	value, ok := response["error"]
+
+	assert.Nil(t, err)
+	assert.True(t, ok)
+
+	expectedBody := gin.H{
+		"error": "Workflow missing name",
+	}
+	assert.Equal(t, expectedBody["error"], value)
+}
+
+func TestRegisterWorkflow(t *testing.T) {
+	dataStore := store.NewDataStoreMock()
+	router := NewRouter(dataStore)
+
+	w := httptest.NewRecorder()
+	payload := `{
+		"name": "test_workflow",
+		"description": "Test workflow",
+		"version": 4,
+		"tasks": [
+			{
+				"name": "test_http_call",
+				"type": "http",
+				"taskdef": {
+					"uri": "http://localhost:8000",
+					"method": "POST",
+					"body": "{\"device_id\": \"${workflow.input.device_id}\"}",
+					"connectionTimeOut": 1000,
+					"readTimeOut": 1000
+				}
+			}
+		],
+		"inputParameters": [
+			"device_id"
+		],
+		"schemaVersion": 1
+	}`
+
+	req, err := http.NewRequest("POST", "/api/v1/metadata/workflows", strings.NewReader(payload))
+	assert.NoError(t, err)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, 201, w.Code)
+
+	workflow, err := dataStore.GetWorkflowByName("test_workflow")
+	assert.NotNil(t, workflow)
+	assert.Equal(t, "test_workflow", workflow.Name)
+	assert.Equal(t, "Test workflow", workflow.Description)
+	assert.Equal(t, 4, workflow.Version)
+	assert.Equal(t, 1, workflow.SchemaVersion)
+}
+
+func TestGetWorkflows(t *testing.T) {
+	taskdef := model.HTTPTask{
+		URI:               "http://localhost:8000",
+		Method:            "POST",
+		Body:              "{\"device_id\": \"${workflow.input.device_id}\"}",
+		ConnectionTimeOut: 1000,
+		ReadTimeOut:       1000,
+	}
+	taskdefJSON, _ := json.Marshal(taskdef)
+	workflow := model.Workflow{
+		Name:        "test_workflow",
+		Description: "Test workflow",
+		Version:     4,
+		Tasks: []model.Task{
+			model.Task{
+				Name:    "test_http_call",
+				Type:    "http",
+				Taskdef: taskdefJSON,
+			},
+		},
+		InputParameters: []string{
+			"device_id",
+		},
+		SchemaVersion: 1,
+	}
+
+	dataStore := store.NewDataStoreMock()
+	dataStore.InsertWorkflows(workflow)
+	router := NewRouter(dataStore)
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/api/v1/metadata/workflows", nil)
+	assert.NoError(t, err)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var workflows []model.Workflow
+	body := w.Body.Bytes()
+	err = json.Unmarshal(body, &workflows)
+
+	assert.Nil(t, err)
+	assert.Len(t, workflows, 1)
+	assert.Equal(t, "test_workflow", workflows[0].Name)
+	assert.Equal(t, "Test workflow", workflows[0].Description)
+	assert.Equal(t, 4, workflows[0].Version)
+	assert.Equal(t, 1, workflows[0].SchemaVersion)
 }

--- a/app/worker/http.go
+++ b/app/worker/http.go
@@ -1,0 +1,78 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package worker
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/mendersoftware/workflows/model"
+)
+
+var makeHTTPRequest = func(req *http.Request, timeout time.Duration) (*http.Response, error) {
+	var httpClient = &http.Client{
+		Timeout: timeout,
+	}
+	res, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
+	workflow *model.Workflow) (*model.TaskResult, error) {
+	uri := processJobString(httpTask.URI, workflow, job)
+	payloadString := processJobString(httpTask.Body, workflow, job)
+	payload := strings.NewReader(payloadString)
+
+	req, err := http.NewRequest(httpTask.Method, uri, payload)
+	if err != nil {
+		return nil, err
+	}
+
+	var headersToBeSent []string
+	for name, value := range httpTask.Headers {
+		headerValue := processJobString(value, workflow, job)
+		req.Header.Add(name, headerValue)
+		headersToBeSent = append(headersToBeSent,
+			fmt.Sprintf("%s: %s", name, headerValue))
+	}
+	res, err := makeHTTPRequest(req, time.Duration(httpTask.ReadTimeOut)*time.Second)
+	if err != nil {
+		return nil, err
+	}
+
+	defer res.Body.Close()
+	resBody, _ := ioutil.ReadAll(res.Body)
+
+	result := &model.TaskResult{
+		Request: model.TaskResultRequest{
+			URI:     uri,
+			Method:  httpTask.Method,
+			Body:    payloadString,
+			Headers: headersToBeSent,
+		},
+		Response: model.TaskResultResponse{
+			StatusCode: res.StatusCode,
+			Body:       string(resBody),
+		},
+	}
+
+	return result, nil
+}

--- a/app/worker/http.go
+++ b/app/worker/http.go
@@ -61,14 +61,28 @@ func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
 	defer res.Body.Close()
 	resBody, _ := ioutil.ReadAll(res.Body)
 
+	var success bool
+	if len(httpTask.StatusCodes) == 0 {
+		success = true
+	} else {
+		success = false
+		for _, statusCode := range httpTask.StatusCodes {
+			if statusCode == res.StatusCode {
+				success = true
+				break
+			}
+		}
+	}
+
 	result := &model.TaskResult{
-		Request: model.TaskResultRequest{
+		Success: success,
+		Request: model.TaskResultHTTPRequest{
 			URI:     uri,
 			Method:  httpTask.Method,
 			Body:    payloadString,
 			Headers: headersToBeSent,
 		},
-		Response: model.TaskResultResponse{
+		Response: model.TaskResultHTTPResponse{
 			StatusCode: res.StatusCode,
 			Body:       string(resBody),
 		},

--- a/app/worker/process.go
+++ b/app/worker/process.go
@@ -1,0 +1,92 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/mendersoftware/go-lib-micro/log"
+	"github.com/mendersoftware/workflows/model"
+	"github.com/mendersoftware/workflows/store"
+)
+
+func processJob(ctx context.Context, job *model.Job,
+	dataStore store.DataStore) error {
+
+	l := log.FromContext(ctx)
+	workflow, err := dataStore.GetWorkflowByName(job.WorkflowName)
+	if err != nil {
+		l.Warnf("The workflow %q of job %s does not exist",
+			job.WorkflowName, job.ID)
+		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
+	acquiredJob, err := dataStore.AquireJob(ctx, job)
+	if err != nil {
+		l.Error(err.Error())
+		return err
+	} else if acquiredJob == nil {
+		l.Warnf("The job with given ID (%s) does not exist", job.ID)
+		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+	job = acquiredJob
+
+	l.Infof("%s: started, %s", job.ID, job.WorkflowName)
+
+	for _, task := range workflow.Tasks {
+		switch task.Type {
+		case "http":
+			var httpTask model.HTTPTask
+			err := json.Unmarshal(task.Taskdef, &httpTask)
+			if err != nil {
+				err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
+				if err != nil {
+					return err
+				}
+				return fmt.Errorf(
+					"Error: Task definition incompatible " +
+						"with specified type (http)")
+			}
+			results, err := processHTTPTask(&httpTask, job, workflow)
+			if err != nil {
+				dataStore.UpdateJobStatus(ctx, job,
+					model.StatusFailure)
+				return err
+			}
+			err = dataStore.UpdateJobAddResult(ctx, job, results)
+			if err != nil {
+				l.Errorf("Error uploading results: %s", err.Error())
+			}
+		}
+	}
+
+	err = dataStore.UpdateJobStatus(ctx, job, model.StatusDone)
+	if err != nil {
+		l.Warn("Unable to set job status to done")
+	}
+
+	l.Infof("%s: done", job.ID)
+	return nil
+}

--- a/app/worker/process_test.go
+++ b/app/worker/process_test.go
@@ -1,0 +1,171 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package worker
+
+import (
+	"context"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/mendersoftware/workflows/model"
+	store "github.com/mendersoftware/workflows/store/mock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessJob(t *testing.T) {
+	context := context.Background()
+	dataStore := store.NewDataStoreMock()
+
+	taskdef := model.HTTPTask{
+		URI:    "http://localhost",
+		Method: "GET",
+		Headers: map[string]string{
+			"X-Header": "Value",
+		},
+	}
+	taskdefJSON, _ := json.Marshal(taskdef)
+
+	workflow := &model.Workflow{
+		Name: "test",
+		Tasks: []model.Task{
+			model.Task{
+				Name:    "task_1",
+				Type:    "http",
+				Taskdef: taskdefJSON,
+			},
+		},
+	}
+	dataStore.InsertWorkflows(*workflow)
+
+	job := &model.Job{
+		WorkflowName: workflow.Name,
+		Status:       model.StatusPending,
+	}
+	job, _ = dataStore.InsertJob(context, job)
+
+	makeHTTPRequestOriginal := makeHTTPRequest
+	requestBody := "BODY"
+	makeHTTPRequest = func(req *http.Request, timeout time.Duration) (*http.Response, error) {
+		resp := &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(strings.NewReader(requestBody)),
+		}
+		return resp, nil
+	}
+	err := processJob(context, job, dataStore)
+	makeHTTPRequest = makeHTTPRequestOriginal
+
+	assert.Nil(t, err)
+
+	job, _ = dataStore.GetJobByNameAndID(context, job.WorkflowName, job.ID)
+	assert.Equal(t, model.StatusDone, job.Status)
+	assert.Len(t, job.Results, 1)
+	assert.Equal(t, job.Results[0].Request.URI, taskdef.URI)
+	assert.Equal(t, job.Results[0].Request.Method, taskdef.Method)
+	assert.Equal(t, job.Results[0].Request.Headers, []string{
+		"X-Header: Value",
+	})
+	assert.Equal(t, job.Results[0].Response.StatusCode, 200)
+	assert.Equal(t, job.Results[0].Response.Body, requestBody)
+}
+
+func TestProcessJobFailedWorkflowDoesNotExist(t *testing.T) {
+	context := context.Background()
+	dataStore := store.NewDataStoreMock()
+
+	job := &model.Job{
+		WorkflowName: "does_not_exist",
+		Status:       model.StatusPending,
+	}
+	job = dataStore.AppendJob(job)
+
+	err := processJob(context, job, dataStore)
+	assert.Nil(t, err)
+
+	job, _ = dataStore.GetJobByNameAndID(context, job.WorkflowName, job.ID)
+	assert.Equal(t, model.StatusFailure, job.Status)
+}
+
+func TestProcessJobFailedJobIsNotPending(t *testing.T) {
+	context := context.Background()
+	dataStore := store.NewDataStoreMock()
+
+	taskdef := model.HTTPTask{
+		URI:    "http://localhost",
+		Method: "GET",
+		Headers: map[string]string{
+			"X-Header": "Value",
+		},
+	}
+	taskdefJSON, _ := json.Marshal(taskdef)
+
+	workflow := &model.Workflow{
+		Name: "test",
+		Tasks: []model.Task{
+			model.Task{
+				Name:    "task_1",
+				Type:    "http",
+				Taskdef: taskdefJSON,
+			},
+		},
+	}
+	dataStore.InsertWorkflows(*workflow)
+
+	job := &model.Job{
+		WorkflowName: workflow.Name,
+		Status:       model.StatusDone,
+	}
+	job, _ = dataStore.InsertJob(context, job)
+
+	err := processJob(context, job, dataStore)
+	assert.Nil(t, err)
+
+	job, _ = dataStore.GetJobByNameAndID(context, job.WorkflowName, job.ID)
+	assert.Equal(t, model.StatusFailure, job.Status)
+}
+
+func TestProcessJobFailedIncompatibleDefinition(t *testing.T) {
+	context := context.Background()
+	dataStore := store.NewDataStoreMock()
+
+	workflow := &model.Workflow{
+		Name: "test",
+		Tasks: []model.Task{
+			model.Task{
+				Name:    "task_1",
+				Type:    "http",
+				Taskdef: json.RawMessage(""),
+			},
+		},
+	}
+	dataStore.InsertWorkflows(*workflow)
+
+	job := &model.Job{
+		WorkflowName: workflow.Name,
+		Status:       model.StatusPending,
+	}
+	job, _ = dataStore.InsertJob(context, job)
+
+	err := processJob(context, job, dataStore)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Error: Task definition incompatible with specified type (http)")
+
+	job, _ = dataStore.GetJobByNameAndID(context, job.WorkflowName, job.ID)
+	assert.Equal(t, model.StatusFailure, job.Status)
+}

--- a/app/worker/utils.go
+++ b/app/worker/utils.go
@@ -1,0 +1,32 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package worker
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/mendersoftware/workflows/model"
+)
+
+func processJobString(data string, workflow *model.Workflow, job *model.Job) string {
+	for _, param := range job.InputParameters {
+		data = strings.Replace(data,
+			fmt.Sprintf("${workflow.input.%s}", param.Name),
+			param.Value, 1)
+	}
+
+	return data
+}

--- a/app/worker/utils_test.go
+++ b/app/worker/utils_test.go
@@ -1,0 +1,42 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package worker
+
+import (
+	"testing"
+
+	"github.com/mendersoftware/workflows/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestProcessJobString(t *testing.T) {
+	workflow := &model.Workflow{
+		Name: "test",
+		InputParameters: []string{
+			"key",
+		},
+	}
+	job := &model.Job{
+		InputParameters: []model.InputParameter{
+			model.InputParameter{
+				Name:  "key",
+				Value: "test",
+			},
+		},
+	}
+
+	res := processJobString("_${workflow.input.key}_", workflow, job)
+	assert.Equal(t, "_test_", res)
+}

--- a/app/worker/worker.go
+++ b/app/worker/worker.go
@@ -16,15 +16,9 @@ package worker
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"io/ioutil"
-	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
-	"time"
 
 	"github.com/mendersoftware/go-lib-micro/config"
 	"github.com/mendersoftware/go-lib-micro/log"
@@ -64,121 +58,4 @@ func InitAndRun(conf config.Reader, dataStore store.DataStore) error {
 	}
 
 	return nil
-}
-
-func processJob(ctx context.Context, job *model.Job,
-	dataStore store.DataStore) error {
-
-	l := log.FromContext(ctx)
-	workflow, err := dataStore.GetWorkflowByName(job.WorkflowName)
-	if err != nil {
-		l.Warnf("The workflow %q of job %s does not exist",
-			job.WorkflowName, job.ID)
-		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	job, err = dataStore.AquireJob(ctx, job)
-	if err != nil {
-		l.Error(err.Error())
-		return err
-	} else if job == nil {
-		l.Warnf("The job with given ID (%s) does not exist", job.ID)
-		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
-		if err != nil {
-			return err
-		}
-		return nil
-	}
-
-	l.Infof("%s: started, %s", job.ID, job.WorkflowName)
-
-	for _, task := range workflow.Tasks {
-		switch task.Type {
-		case "http":
-			var httpTask model.HTTPTask
-			err := json.Unmarshal(task.Taskdef, &httpTask)
-			if err != nil {
-				return fmt.Errorf(
-					"Error: Task definition incompatible " +
-						"with specified type (http)")
-			}
-			results, err := processHTTPTask(&httpTask, job, workflow)
-			if err != nil {
-				dataStore.UpdateJobStatus(ctx, job,
-					model.StatusFailure)
-				return err
-			}
-			err = dataStore.UpdateJobAddResult(ctx, job, results)
-			if err != nil {
-				l.Errorf("Error uploading results: %s", err.Error())
-			}
-		}
-	}
-
-	err = dataStore.UpdateJobStatus(ctx, job, model.StatusDone)
-	if err != nil {
-		l.Warn("Unable to set job status to done")
-	}
-
-	l.Infof("%s: done", job.ID)
-	return nil
-}
-
-func processJobString(data string, workflow *model.Workflow, job *model.Job) string {
-	for _, param := range job.InputParameters {
-		data = strings.Replace(data,
-			fmt.Sprintf("${workflow.input.%s}", param.Name),
-			param.Value, 1)
-	}
-
-	return data
-}
-
-func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
-	workflow *model.Workflow) (*model.TaskResult, error) {
-	uri := processJobString(httpTask.URI, workflow, job)
-	payloadString := processJobString(httpTask.Body, workflow, job)
-	payload := strings.NewReader(payloadString)
-
-	req, err := http.NewRequest(httpTask.Method, uri, payload)
-	if err != nil {
-		return nil, err
-	}
-
-	var headersToBeSent []string
-	for name, value := range httpTask.Headers {
-		headerValue := processJobString(value, workflow, job)
-		req.Header.Add(name, headerValue)
-		headersToBeSent = append(headersToBeSent,
-			fmt.Sprintf("%s: %s", name, headerValue))
-	}
-	var netClient = &http.Client{
-		Timeout: time.Duration(httpTask.ReadTimeOut) * time.Second,
-	}
-	res, err := netClient.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	defer res.Body.Close()
-	resBody, _ := ioutil.ReadAll(res.Body)
-
-	result := &model.TaskResult{
-		Request: model.TaskResultRequest{
-			URI:     uri,
-			Method:  httpTask.Method,
-			Body:    payloadString,
-			Headers: headersToBeSent,
-		},
-		Response: model.TaskResultResponse{
-			StatusCode: res.StatusCode,
-			Body:       string(resBody),
-		},
-	}
-
-	return result, nil
 }

--- a/docs/workflows_api.yml
+++ b/docs/workflows_api.yml
@@ -174,6 +174,10 @@ definitions:
         type: string
       headers:
         type: object
+      statusCodes:
+        type: array
+        items:
+          type: integer
       connectionTimeOut:
         type: integer
       readTimeOut:
@@ -236,7 +240,7 @@ definitions:
         name: key
         value: parameter
 
-  TaskResultRequest:
+  TaskResultHTTPRequest:
     type: object
     properties:
       statusCode:
@@ -244,7 +248,7 @@ definitions:
       body:
         type: string
 
-  TaskResultResponse:
+  TaskResultHTTPResponse:
     type: object
     properties:
       uri:
@@ -261,10 +265,12 @@ definitions:
   TaskResult:
     type: object
     properties:
+      success:
+        type: boolean
       request:
-        $ref: "#/definitions/TaskResultRequest"
+        $ref: "#/definitions/TaskResultHTTPRequest"
       response:
-        $ref: "#/definitions/TaskResultResponse"
+        $ref: "#/definitions/TaskResultHTTPResponse"
 
   JobStatus:
     type: object

--- a/model/job.go
+++ b/model/job.go
@@ -50,7 +50,7 @@ type Job struct {
 
 	// Results produced by a finished job. If status is not "done" this
 	// field will always be nil.
-	Results *[]TaskResult `json:"results" bson:"results"`
+	Results []TaskResult `json:"results" bson:"results"`
 }
 
 // InputParameter defines the input parameter of a job

--- a/model/job.go
+++ b/model/job.go
@@ -64,20 +64,21 @@ type InputParameter struct {
 
 // TaskResult contains the result of the execution of a task
 type TaskResult struct {
-	Request  TaskResultRequest  `json:"request" bson:"request"`
-	Response TaskResultResponse `json:"response" bson:"response"`
+	Success  bool                   `json:"success" bson:"success"`
+	Request  TaskResultHTTPRequest  `json:"request" bson:"request"`
+	Response TaskResultHTTPResponse `json:"response" bson:"response"`
 }
 
-// TaskResultRequest contains the request
-type TaskResultRequest struct {
+// TaskResultHTTPRequest contains the request
+type TaskResultHTTPRequest struct {
 	URI     string   `json:"uri" bson:"uri"`
 	Method  string   `json:"method" bson:"method"`
 	Body    string   `json:"body" bson:"body"`
 	Headers []string `json:"headers" bson:"headers"`
 }
 
-// TaskResultResponse contains the response
-type TaskResultResponse struct {
+// TaskResultHTTPResponse contains the response
+type TaskResultHTTPResponse struct {
 	StatusCode int    `json:"statusCode" bson:"status_code"`
 	Body       string `json:"body" bson:"body"`
 }

--- a/model/job_test.go
+++ b/model/job_test.go
@@ -1,0 +1,69 @@
+// Copyright 2019 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStatusToString(t *testing.T) {
+	assert.Equal(t, "pending", StatusToString(StatusPending))
+	assert.Equal(t, "processing", StatusToString(StatusProcessing))
+	assert.Equal(t, "done", StatusToString(StatusDone))
+	assert.Equal(t, "pending", StatusToString(StatusPending))
+	assert.Equal(t, "failed", StatusToString(StatusFailure))
+	assert.Equal(t, "unknown", StatusToString(999999))
+}
+
+func TestValidateWithoutErrors(t *testing.T) {
+	workflow := &Workflow{
+		Name: "test",
+		InputParameters: []string{
+			"key",
+		},
+	}
+	job := Job{
+		InputParameters: []InputParameter{
+			InputParameter{
+				Name:  "key",
+				Value: "test",
+			},
+		},
+	}
+	err := job.Validate(workflow)
+	assert.Nil(t, err)
+}
+func TestValidateWithErrors(t *testing.T) {
+	workflow := &Workflow{
+		Name: "test",
+		InputParameters: []string{
+			"key",
+			"missing_key",
+		},
+	}
+	job := Job{
+		InputParameters: []InputParameter{
+			InputParameter{
+				Name:  "key",
+				Value: "test",
+			},
+		},
+	}
+	err := job.Validate(workflow)
+	assert.NotNil(t, err)
+	assert.EqualError(t, err, "Missing input parameters: [missing_key]")
+}

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -50,6 +50,7 @@ type HTTPTask struct {
 	Method            string            `json:"method"`
 	ContentType       string            `json:"contentType,omitempty"`
 	Body              string            `json:"body,omitempty"`
+	StatusCodes       []int             `json:"statusCodes,omitempty"`
 	Headers           map[string]string `json:"headers"`
 	ConnectionTimeOut int               `json:"connectionTimeOut"`
 	ReadTimeOut       int               `json:"readTimeOut"`

--- a/model/workflow_test.go
+++ b/model/workflow_test.go
@@ -42,6 +42,10 @@ func TestParseWorkflowFromJSON(t *testing.T) {
 					"X-MEN-RequestID": "${workflow.input.request_id}",
 					"Authorization": "${workflow.input.authorization}"
 				},
+				"statusCodes": [
+					200,
+					201
+				],
 				"connectionTimeOut": 1000,
 				"readTimeOut": 1000
 			}
@@ -80,6 +84,9 @@ func TestParseWorkflowFromJSON(t *testing.T) {
 	assert.Equal(t, httpTask.Method, "DELETE")
 	assert.Equal(t, httpTask.Body, "Payload")
 	assert.Len(t, httpTask.Headers, 2)
+	assert.Len(t, httpTask.StatusCodes, 2)
+	assert.Equal(t, httpTask.StatusCodes[0], 200)
+	assert.Equal(t, httpTask.StatusCodes[1], 201)
 	assert.Equal(t, httpTask.Headers["X-MEN-RequestID"], "${workflow.input.request_id}")
 	assert.Equal(t, httpTask.Headers["Authorization"], "${workflow.input.authorization}")
 	assert.Equal(t, httpTask.ConnectionTimeOut, 1000)

--- a/store/mock/datastore_mock.go
+++ b/store/mock/datastore_mock.go
@@ -103,6 +103,11 @@ func (db *DataStoreMock) UpdateJobStatus(ctx context.Context, job *model.Job,
 // GetJobStatusByNameAndID get the task execution status for a job status bu Name and ID
 func (db *DataStoreMock) GetJobByNameAndID(ctx context.Context,
 	name string, ID string) (*model.Job, error) {
+	for _, job := range db.Jobs {
+		if job.WorkflowName == name && job.ID == ID {
+			return &job, nil
+		}
+	}
 	return nil, nil
 }
 


### PR DESCRIPTION
Workflow definition support nows an optional list of response status codes to be considered valid. If the list is populated with at least one item, the HTTP status code of the response is checked to determine if the task was successful or not.

If a workflow task fails, the workflow is stopped and the status is set to StatusFailure.