### PR TITLE
Avoid race condition when starting a workflow

### DIFF
--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -278,15 +278,28 @@ func (db *DataStoreMongo) InsertJob(
 	collQueue := database.Collection(JobQueueCollectionName)
 	collJobs := database.Collection(JobsCollectionName)
 
-	// insert the same pending job into the global collection
-	if _, err := collJobs.InsertOne(ctx, job); err != nil {
-		return nil, errors.Wrap(err,
-			"Error inserting job into jobs collection")
+	var session mongo.Session
+	var err error
+
+	if session, err = db.client.StartSession(); err != nil {
+		return nil, err
 	}
-	// insert the Job in the capped transaction we use as message queue
-	if _, err := collQueue.InsertOne(ctx, job); err != nil {
-		return nil, errors.Wrap(err,
-			"Error inserting job to message queue")
+	defer session.EndSession(ctx)
+
+	if err = mongo.WithSession(ctx, session, func(sc mongo.SessionContext) error {
+		// insert the same pending job into the global collection
+		if _, err := collJobs.InsertOne(ctx, job); err != nil {
+			return errors.Wrap(err,
+				"Error inserting job into jobs collection")
+		}
+		// insert the Job in the capped transaction we use as message queue
+		if _, err := collQueue.InsertOne(ctx, job); err != nil {
+			return errors.Wrap(err,
+				"Error inserting job to message queue")
+		}
+		return nil
+	}); err != nil {
+		return nil, err
 	}
 
 	return job, nil

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -278,15 +278,15 @@ func (db *DataStoreMongo) InsertJob(
 	collQueue := database.Collection(JobQueueCollectionName)
 	collJobs := database.Collection(JobsCollectionName)
 
-	// insert the Job in the capped transaction we use as message queue
-	if _, err := collQueue.InsertOne(ctx, job); err != nil {
-		return nil, errors.Wrap(err,
-			"Error inserting job to message queue")
-	}
 	// insert the same pending job into the global collection
 	if _, err := collJobs.InsertOne(ctx, job); err != nil {
 		return nil, errors.Wrap(err,
 			"Error inserting job into jobs collection")
+	}
+	// insert the Job in the capped transaction we use as message queue
+	if _, err := collQueue.InsertOne(ctx, job); err != nil {
+		return nil, errors.Wrap(err,
+			"Error inserting job to message queue")
 	}
 
 	return job, nil


### PR DESCRIPTION
Change the order of insertion of the Job in the queue and generic jobs
collections. If we insert the job in the queue before inserting it into
the generic jobs collection, we can have a race condition when a worker
picks up the job before the server completed the insertion.