### PR TITLE
MEN-3240 update device status workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,9 +11,11 @@
 *.rej
 *.exe
 .*.swp
+workflows
 
 coverage.txt
 coverage-acceptance.txt
 coverage-acceptance-worker.txt
 ./bin/
 .vscode/
+.idea

--- a/Dockerfile.acceptance-testing.worker
+++ b/Dockerfile.acceptance-testing.worker
@@ -17,10 +17,11 @@ COPY ./worker/config.yaml /etc/workflows/config.yaml
 COPY --from=builder /go/src/github.com/mendersoftware/workflows/workflows-test /usr/bin
 COPY ./worker/decommission_device.json /etc/workflows/definitions/decommission_device.json
 COPY ./worker/provision_device.json /etc/workflows/definitions/provision_device.json
+COPY ./worker/update_device_status.json /etc/workflows/definitions/update_device_status.json
 ENTRYPOINT [ \
     "/usr/bin/workflows-test", \
     "-test.coverprofile=/testing/coverage-acceptance-worker.txt", \
     "-acceptance-tests", \
     "-test.run=TestRunMain", \
-    "-cli-args=--config=/etc/workflows/config.yaml worker --automigrate --workflows=decommission_device,provision_device --excluded-workflows=generate_artifact" \
+    "-cli-args=--config=/etc/workflows/config.yaml worker --automigrate --workflows=decommission_device,provision_device,update_device_status --excluded-workflows=generate_artifact" \
 ]

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -16,4 +16,5 @@ COPY ./worker/config.yaml /etc/workflows/config.yaml
 COPY --from=builder /go/src/github.com/mendersoftware/workflows/workflows /usr/bin
 COPY ./worker/decommission_device.json /etc/workflows/definitions/decommission_device.json
 COPY ./worker/provision_device.json /etc/workflows/definitions/provision_device.json
+COPY ./worker/update_device_status.json /etc/workflows/definitions/update_device_status.json
 ENTRYPOINT ["/usr/bin/workflows", "--config", "/etc/workflows/config.yaml", "worker"]

--- a/tests/mmock/inventory_POST_devices_v2.json
+++ b/tests/mmock/inventory_POST_devices_v2.json
@@ -1,0 +1,10 @@
+{
+	"description": "inventory: POST devices v2",
+	"request": {
+		"method": "POST",
+		"path": "/api/internal/v2/inventory/devices/1/accepted"
+	},
+	"response": {
+		"statusCode": 200
+	}
+}

--- a/tests/tests/test_update_device_status.py
+++ b/tests/tests/test_update_device_status.py
@@ -1,0 +1,72 @@
+import requests
+import time
+
+
+def test_update_device_status(mmock_url, workflows_url):
+    # start the provision_device workflow
+    request_id = "1234567890"
+    device_status = "accepted"
+    device_ids = '["1","2","3"]'
+    tenant_id = "1"
+    res = requests.post(
+        workflows_url + "/api/v1/workflow/update_device_status",
+        json={
+            "request_id": request_id,
+            "device_ids": device_ids,
+            "device_status": device_status,
+            "tenant_id": tenant_id,
+        },
+    )
+    assert res.status_code == 201
+    # verify the response
+    response = res.json()
+    assert response is not None
+    assert type(response) is dict
+    assert response["name"] == "update_device_status"
+    assert response["id"] is not None
+    # get the job details, every second until done
+    for i in range(10):
+        time.sleep(1)
+        res = requests.get(
+            workflows_url + "/api/v1/workflow/update_device_status/" + response["id"]
+        )
+        assert res.status_code == 200
+        # if status is done, break
+        response = res.json()
+        assert response is not None
+        assert type(response) is dict
+        if response["status"] == "done":
+            break
+    # verify the status
+    assert {"name": "request_id", "value": request_id} in response["inputParameters"]
+    assert {"name": "device_ids", "value": device_ids} in response["inputParameters"]
+    assert response["status"] == "done"
+    assert len(response["results"]) == 1
+    assert response["results"][0]["success"] == True
+    assert response["results"][0]["httpResponse"]["statusCode"] == 200
+    #  verify the mock server has been correctly called
+    res = requests.get(mmock_url + "/api/request/all")
+    assert res.status_code == 200
+    response = res.json()
+    assert len(response) == 1
+    expected = {
+        "request": {
+            "scheme": "http",
+            "host": "mender-inventory",
+            "port": "8080",
+            "method": "POST",
+            "path": "/api/internal/v2/inventory/devices/" + tenant_id + "/" + device_status,
+            "queryStringParameters": {},
+            "fragment": "",
+            "headers": {
+                "Content-Type": ["application/json"],
+                "Accept-Encoding": ["gzip"],
+                "Content-Length": ["13"],
+                "User-Agent": ["Go-http-client/1.1"],
+                "X-Men-Requestid": [request_id],
+            },
+            "cookies": {},
+            "body": device_ids,
+        },
+    }
+    assert expected["request"] == response[0]["request"]

--- a/worker/update_device_status.json
+++ b/worker/update_device_status.json
@@ -1,0 +1,29 @@
+{
+    "name": "update_device_status",
+    "description": "Update device status.",
+    "version": 1,
+    "tasks": [
+        {
+            "name": "update_device_identity_inventory",
+            "type": "http",
+            "retries": 3,
+            "http": {
+                "uri": "http://mender-inventory:8080/api/internal/v2/inventory/devices/${workflow.input.tenant_id}/${workflow.input.device_status}",
+                "method": "POST",
+                "contentType": "application/json",
+                "body": "${workflow.input.device_ids}",
+                "headers": {
+                    "X-MEN-RequestID": "${workflow.input.request_id}"
+                },
+                "connectionTimeOut": 8000,
+                "readTimeOut": 8000
+            }
+        }
+    ],
+    "inputParameters": [
+        "request_id",
+        "device_ids",
+        "device_status",
+        "tenant_id"
+    ]
+}


### PR DESCRIPTION
Update device status workflow
--

* **deviceauth** calls _update_device_status_ [[1](https://github.com/mendersoftware/workflows/pull/40)] workflow to propagate information on device status to inventory.
* **inventory** exposes internal API to set status for a list of devices [[2](https://github.com/mendersoftware/inventory-enterprise/pull/24)].
* _/filters/search_ can be use by UI to get list of devices as a single place of information.

related PRs:
 * [1] https://github.com/mendersoftware/workflows/pull/40
 * [2] https://github.com/mendersoftware/inventory/pull/162
 * [3] https://github.com/mendersoftware/deviceauth/pull/324

ChangeLog:none
Signed-off-by: Peter Grzybowski <peter@northern.tech>