### PR TITLE
API spec fixes: schema and hostname

### DIFF
--- a/docs/workflows_api.yml
+++ b/docs/workflows_api.yml
@@ -8,7 +8,7 @@ info:
 
 host: 'docker.mender.io'
 schemes:
-  - https
+  - http
 
 responses:
   NotFoundError: # 404

--- a/docs/workflows_api.yml
+++ b/docs/workflows_api.yml
@@ -6,7 +6,7 @@ info:
     An API for workflow management.
     Intended for use by other services.
 
-host: 'docker.mender.io'
+host: 'mender-workflows-server:8080'
 schemes:
   - http
 


### PR DESCRIPTION
* [API spec] Consistently use host hosted.mender.io across all repos
* [API spec] Consistently use https schemes across all repos
