### PR TITLE
MEN-3619: Optional input parameters and go template request body

### DIFF
--- a/app/worker/http.go
+++ b/app/worker/http.go
@@ -40,6 +40,10 @@ func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
 	workflow *model.Workflow, l *log.Logger) (*model.TaskResult, error) {
 	uri := processJobString(httpTask.URI, workflow, job)
 	payloadString := processJobString(httpTask.Body, workflow, job)
+	payloadString = maybeExecuteGoTemplate(
+		payloadString,
+		job.InputParameters.Map(),
+	)
 	payload := strings.NewReader(payloadString)
 
 	req, err := http.NewRequest(httpTask.Method, uri, payload)

--- a/app/worker/http.go
+++ b/app/worker/http.go
@@ -72,6 +72,9 @@ func processHTTPTask(httpTask *model.HTTPTask, job *model.Job,
 	var success bool
 	if len(httpTask.StatusCodes) == 0 {
 		success = true
+		if res.StatusCode >= 400 {
+			success = false
+		}
 	} else {
 		success = false
 		for _, statusCode := range httpTask.StatusCodes {

--- a/go.mod
+++ b/go.mod
@@ -12,4 +12,5 @@ require (
 	github.com/urfave/cli v1.22.4
 	go.mongodb.org/mongo-driver v1.3.3
 	golang.org/x/sys v0.0.0-20200602100848-8d3cce7afc34
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
 )

--- a/model/job.go
+++ b/model/job.go
@@ -44,7 +44,7 @@ type Job struct {
 	WorkflowName string `json:"workflowName" bson:"workflow_name"`
 
 	// InputParameters contains the name of the workflow
-	InputParameters []InputParameter `json:"inputParameters" bson:"input_parameters"`
+	InputParameters InputParameters `json:"inputParameters" bson:"input_parameters"`
 
 	// Enumerated status of the Job and string field used for unmarshalling
 	Status       int    `json:"-" bson:"status"`
@@ -65,6 +65,16 @@ type InputParameter struct {
 
 	// Value of the input parameter
 	Value string `json:"value" bson:"value"`
+}
+
+type InputParameters []InputParameter
+
+func (param InputParameters) Map() map[string]interface{} {
+	var ret = map[string]interface{}{}
+	for _, val := range param {
+		ret[val.Name] = val.Value
+	}
+	return ret
 }
 
 // TaskResult contains the result of the execution of a task

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/mendersoftware/go-lib-micro/log"
 	"github.com/pkg/errors"
+	"gopkg.in/yaml.v3"
 )
 
 // Workflow stores the definition of a workflow
@@ -54,12 +55,19 @@ func GetWorkflowsFromPath(path string) map[string]*Workflow {
 	}
 
 	for _, f := range files {
-		if !strings.HasSuffix(f.Name(), ".json") {
+		if !(strings.HasSuffix(f.Name(), ".json") ||
+			strings.HasSuffix(f.Name(), ".yml") ||
+			strings.HasSuffix(f.Name(), ".yaml")) {
 			continue
 		}
 		fn := filepath.Join(path, f.Name())
 		if data, err := ioutil.ReadFile(fn); err == nil {
-			workflow, err := ParseWorkflowFromJSON([]byte(data))
+			var workflow = &Workflow{}
+			if strings.HasSuffix(f.Name(), ".json") {
+				workflow, err = ParseWorkflowFromJSON(data)
+			} else {
+				err = yaml.Unmarshal(data, workflow)
+			}
 			if err != nil {
 				l.Warn(err.Error())
 				continue

--- a/model/workflow.go
+++ b/model/workflow.go
@@ -26,12 +26,13 @@ import (
 
 // Workflow stores the definition of a workflow
 type Workflow struct {
-	Name            string   `json:"name" bson:"_id"`
-	Description     string   `json:"description" bson:"description"`
-	Version         int      `json:"version" bson:"version"`
-	SchemaVersion   int      `json:"schemaVersion" bson:"schema_version"`
-	Tasks           []Task   `json:"tasks" bson:"tasks"`
-	InputParameters []string `json:"inputParameters" bson:"input_parameters"`
+	Name               string   `json:"name" bson:"_id"`
+	Description        string   `json:"description" bson:"description"`
+	Version            int      `json:"version" bson:"version"`
+	SchemaVersion      int      `json:"schemaVersion" bson:"schema_version"`
+	Tasks              []Task   `json:"tasks" bson:"tasks"`
+	InputParameters    []string `json:"inputParameters" bson:"input_parameters"`
+	OptionalParameters []string `json:"optionalParameters" bson:"optional_parameters,omitempty"`
 }
 
 // ParseWorkflowFromJSON parse a JSON string and returns a Workflow struct

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -165,4 +165,5 @@ gopkg.in/ini.v1
 # gopkg.in/yaml.v2 v2.2.8
 gopkg.in/yaml.v2
 # gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c
+## explicit
 gopkg.in/yaml.v3


### PR DESCRIPTION
This commit brings in go template to specify http task's request body and adds an additional optionalParameters to the workflow structure (this attribute is merely for documentation purposes as it's not actually used).
Moreover, I also added support for yaml-file workflow definitions as I find it more readable, and changed the default http task failure criteria to include erroneous http status codes ( >= 400).