### PR TITLE
MC-3311: replace gin-gonic logger with a custom logrus one

### DIFF
--- a/api/http/logger.go
+++ b/api/http/logger.go
@@ -1,0 +1,69 @@
+// Copyright 2020 Northern.tech AS
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+
+package http
+
+import (
+	"fmt"
+	"math"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/sirupsen/logrus"
+)
+
+const typeHTTP = "http"
+
+func routerLogger(logger logrus.FieldLogger) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// other handler can change c.Path so:
+		path := c.Request.URL.Path
+		start := time.Now()
+		c.Next()
+		stop := time.Since(start)
+		latency := math.Ceil(float64(stop.Nanoseconds())) / 1000000.0
+		statusCode := c.Writer.Status()
+		method := c.Request.Method
+		clientIP := c.ClientIP()
+		clientUserAgent := c.Request.UserAgent()
+		dataLength := c.Writer.Size()
+		if dataLength < 0 {
+			dataLength = 0
+		}
+
+		entry := logger.WithFields(logrus.Fields{
+			"clientip":     clientIP,
+			"type":         typeHTTP,
+			"ts":           start.Round(0),
+			"status":       statusCode,
+			"responsetime": latency,
+			"byteswritten": dataLength,
+			"method":       method,
+			"path":         path,
+		})
+
+		if len(c.Errors) > 0 {
+			entry.Error(c.Errors.ByType(gin.ErrorTypePrivate).String())
+		} else {
+			msg := fmt.Sprintf("%d %f %s %s %s - %s", statusCode, latency, method, path, clientIP, clientUserAgent)
+			if statusCode > 499 {
+				entry.Error(msg)
+			} else if statusCode > 399 {
+				entry.Warn(msg)
+			} else {
+				entry.Info(msg)
+			}
+		}
+	}
+}

--- a/api/http/router.go
+++ b/api/http/router.go
@@ -15,7 +15,11 @@
 package http
 
 import (
+	"context"
+
 	"github.com/gin-gonic/gin"
+	"github.com/mendersoftware/go-lib-micro/log"
+
 	"github.com/mendersoftware/workflows/store"
 )
 
@@ -32,8 +36,13 @@ const (
 // NewRouter returns the gin router
 func NewRouter(dataStore store.DataStore) *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
+	gin.DisableConsoleColor()
+
 	router := gin.New()
-	router.Use(gin.Logger())
+	ctx := context.Background()
+	l := log.FromContext(ctx)
+
+	router.Use(routerLogger(l))
 	router.Use(gin.Recovery())
 
 	status := NewStatusController()

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/mendersoftware/go-lib-micro v0.0.0-20200529072844-ecc6d0b89fa6
 	github.com/mendersoftware/mendertesting v0.0.1
 	github.com/pkg/errors v0.9.1
+	github.com/sirupsen/logrus v1.6.0
 	github.com/stretchr/testify v1.6.1
 	github.com/thedevsaddam/gojsonq v2.3.0+incompatible
 	github.com/urfave/cli v1.22.4

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/mendersoftware/go-lib-micro v0.0.0-20200529072844-ecc6d0b89fa6 h1:vWR
 github.com/mendersoftware/go-lib-micro v0.0.0-20200529072844-ecc6d0b89fa6/go.mod h1:DHK4Anv1GHr/AxFtjfyAyJ92tZaLcJyc0j/0ndpU1SY=
 github.com/mendersoftware/inventory v0.0.0-20200522065057-a25956b1ec7b/go.mod h1:D1QAZ24QhWlZG/l5Hl0ARFQCRTpFyMSqBqGoCpDWfME=
 github.com/mendersoftware/mendertesting v0.0.0-20200528113222-083aca144cb7/go.mod h1:WZyiX1zeljfyFaTjmbR84+wHjzmPDLDvOdRHZnnLM/0=
-github.com/mendersoftware/mendertesting v0.0.0-20200602125439-77581b5b7449 h1:gnpREMgsw482N3r6yElud3vqIzHweLtRrHJiTNWlw3A=
-github.com/mendersoftware/mendertesting v0.0.0-20200602125439-77581b5b7449/go.mod h1:WZyiX1zeljfyFaTjmbR84+wHjzmPDLDvOdRHZnnLM/0=
 github.com/mendersoftware/mendertesting v0.0.1 h1:Uh3yPaHLEC+27y8ZBpDLtwE1LZaPclKuNBCH+A3oRI4=
 github.com/mendersoftware/mendertesting v0.0.1/go.mod h1:WZyiX1zeljfyFaTjmbR84+wHjzmPDLDvOdRHZnnLM/0=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
@@ -264,8 +262,6 @@ github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXf
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
-github.com/stretchr/testify v1.6.0 h1:jlIyCplCJFULU/01vCkhKuTyc3OorI3bJFuw6obfgho=
-github.com/stretchr/testify v1.6.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -84,6 +84,7 @@ github.com/russross/blackfriday/v2
 # github.com/shurcooL/sanitized_anchor_name v1.0.0
 github.com/shurcooL/sanitized_anchor_name
 # github.com/sirupsen/logrus v1.6.0
+## explicit
 github.com/sirupsen/logrus
 # github.com/spf13/afero v1.1.2
 github.com/spf13/afero


### PR DESCRIPTION
The new logger uses logrus and exports key-values that are compatible
with the ones of the other Mender servicees.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>