### PR TITLE
Align health check endpoints

### DIFF
--- a/api/http/workflow.go
+++ b/api/http/workflow.go
@@ -58,7 +58,7 @@ func (h WorkflowController) HealthCheck(c *gin.Context) {
 		})
 		return
 	}
-	c.Status(http.StatusOK)
+	c.Status(http.StatusNoContent)
 }
 
 // RegisterWorkflow responds to POST /api/v1/metadata/workflows

--- a/api/http/workflow_test.go
+++ b/api/http/workflow_test.go
@@ -41,7 +41,7 @@ func TestHealthCheck(t *testing.T) {
 		HTTPBody     map[string]interface{}
 	}{{
 		Name:       "ok",
-		HTTPStatus: http.StatusOK,
+		HTTPStatus: http.StatusNoContent,
 	}, {
 		Name:         "error, MongoDB not reachable",
 		DataStoreErr: errors.New("connection refused"),

--- a/store/mongo/datastore_mongo.go
+++ b/store/mongo/datastore_mongo.go
@@ -187,7 +187,9 @@ func NewDataStoreWithClient(client *Client, c config.Reader) *DataStoreMongo {
 }
 
 func (db *DataStoreMongo) Ping(ctx context.Context) error {
-	return db.client.Ping(ctx, nil)
+	res := db.client.Database(db.dbName).
+		RunCommand(ctx, bson.M{"ping": 1})
+	return res.Err()
 }
 
 // LoadWorkflows from filesystem if the workflowsPath setting is provided


### PR DESCRIPTION
This PR makes some tiny adjustments to the `GET /health` endpoint aligning the implementation with the other services.
Most importantly: the return code from successful `GET /health` is changed to 204.