### PR TITLE
QA-221: Acceptance tests: migrate to coveralls

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -83,17 +83,6 @@ build:docker:worker:
     DOCKER_REPOSITORY: mendersoftware/workflows-worker
     DOCKERFILE: Dockerfile.worker
 
-publish:acceptance_tests:
-  stage: publish
-  image: alpine
-  dependencies:
-    - test:acceptance_tests
-  before_script:
-    - apk add --no-cache bash curl findutils git
-  script:
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -F acceptance -f ./tests/coverage-acceptance.txt"
-    - bash -c "bash <(curl -s https://codecov.io/bash) -Z -F acceptanceworker -f ./tests/coverage-acceptance-worker.txt"
-
 publish:image:worker:
   extends: publish:image
   dependencies:
@@ -107,3 +96,41 @@ publish:image:mender:worker:
     - build:docker:worker
   variables:
     DOCKER_REPOSITORY: mendersoftware/workflows-worker
+
+publish:acceptance:
+  stage: publish
+  except:
+    - /^saas-[a-zA-Z0-9.]+$/
+  image: golang:1.14-alpine3.11
+  dependencies:
+    - test:acceptance_tests
+  before_script:
+    - apk add --no-cache git
+    # Run go get out of the repo to not modify go.mod
+    - cd / && go get github.com/mattn/goveralls && cd -
+    # Coveralls env variables:
+    #  According to https://docs.coveralls.io/supported-ci-services
+    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
+    #  to goveralls source code (https://github.com/mattn/goveralls)
+    #  many of these are not supported. Set CI_BRANCH, CI_PR_NUMBER,
+    #  and pass few others as command line arguments.
+    #  See also https://docs.coveralls.io/api-reference
+    - export CI_BRANCH=${CI_COMMIT_BRANCH}
+    - export CI_PR_NUMBER=${CI_COMMIT_BRANCH#pr_}
+  script:
+    - goveralls
+      -repotoken ${COVERALLS_TOKEN}
+      -service gitlab-ci
+      -jobid $CI_PIPELINE_ID
+      -covermode set
+      -flagname acceptance
+      -parallel
+      -coverprofile ./tests/coverage-acceptance.txt
+    - goveralls
+      -repotoken ${COVERALLS_TOKEN}
+      -service gitlab-ci
+      -jobid $CI_PIPELINE_ID
+      -covermode set
+      -flagname acceptance-worker
+      -parallel
+      -coverprofile ./tests/coverage-acceptance-worker.txt


### PR DESCRIPTION
This repo was missed in the initial round because it had a custom
publish:acceptance job.