### PR TITLE
Revert "Changelog:All: Bump golang from 1.14-alpine3.12 to 1.15.4-alpine3.12"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15.4-alpine3.12 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache \
     xz-dev \
     musl-dev \

--- a/Dockerfile.acceptance-testing
+++ b/Dockerfile.acceptance-testing
@@ -1,4 +1,4 @@
-FROM golang:1.15.4-alpine3.12 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache \
     xz-dev \
     musl-dev \

--- a/Dockerfile.acceptance-testing.worker
+++ b/Dockerfile.acceptance-testing.worker
@@ -1,4 +1,4 @@
-FROM golang:1.15.4-alpine3.12 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache \
     xz-dev \
     musl-dev \

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -1,4 +1,4 @@
-FROM golang:1.15.4-alpine3.12 as builder
+FROM golang:1.14-alpine3.12 as builder
 RUN apk add --no-cache \
     xz-dev \
     musl-dev \

--- a/go.sum
+++ b/go.sum
@@ -338,7 +338,6 @@ golang.org/x/net v0.0.0-20190503192946-f4e77d36d62c/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190603091049-60506f45cf65/go.mod h1:HSz+uSET+XFnRR8LxR5pz3Of3rY3CfYBVs4xY44aLks=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859 h1:R/3boaszxrf1GEUWTVDzSKVwLmSJpwZ1yqXm8j0v2QI=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20200202094626-16171245cfb2 h1:CCH4IOTTfewWjGOlSp+zGcjutRKlBEZQ6wTn8ozI/nI=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=


### PR DESCRIPTION
This reverts commit 32ca03dc873e17e853d0af5c0c2c44c826a469b9.

Fix inability to upload acceptance test coverage.

Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>