### PR TITLE
Bump the version of the provision_device workflow

### DIFF
--- a/worker/provision_device.json
+++ b/worker/provision_device.json
@@ -1,7 +1,7 @@
 {
   "name": "provision_device",
   "description": "Provision device.",
-  "version": 3,
+  "version": 4,
   "tasks": [
     {
       "name": "create_device_inventory",


### PR DESCRIPTION
The deviceonnect related changes to the workflow require the increment
of the version number of the workflow, otherwise the workflow server and
workers won't pick up the new version.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>