### PR TITLE
Log response time in seconds instead of milliseconds, to make it consistent

### DIFF
--- a/api/http/logger.go
+++ b/api/http/logger.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Northern.tech AS
+// Copyright 2021 Northern.tech AS
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ func routerLogger(logger logrus.FieldLogger) gin.HandlerFunc {
 		start := time.Now()
 		c.Next()
 		stop := time.Since(start)
-		latency := math.Ceil(float64(stop.Nanoseconds())) / 1000000.0
+		latency := math.Ceil(float64(stop.Nanoseconds())/1000000.0) / 1000.0
 		statusCode := c.Writer.Status()
 		method := c.Request.Method
 		clientIP := c.ClientIP()


### PR DESCRIPTION
All the other Mender microservices are logging response time in seconds.

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>