### PR TITLE
Switch IRC link from Freenode to Libera.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,4 +77,4 @@ issue. We thank you in advance for your cooperation.
 * Fork us on [Github](https://github.com/mendersoftware)
 * Create an issue in the [bugtracker](https://tracker.mender.io/projects/MEN)
 * Email us at [contact@mender.io](mailto:contact@mender.io)
-* Connect to the [#mender IRC channel on Freenode](http://webchat.freenode.net/?channels=mender)
+* Connect to the [#mender IRC channel on Libera](https://web.libera.chat/?#mender)


### PR DESCRIPTION
Changelog: None

Signed-off-by: Kristian Amlie <kristian.amlie@northern.tech>