### PR TITLE
removed deprecated ci job image overrides to align with ci templates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,11 +40,7 @@ test:prepare_acceptance:
       - prtest_image.tar
       - prtest_worker_image.tar
 
-test:static:
-  image: golang:1.14
-
 test:unit:
-  image: golang:1.14
   services:
     - mongo:4.4
   variables:


### PR DESCRIPTION
Changelog: None
Signed-off-by: Manuel Zedel <manuel.zedel@northern.tech>