### PR TITLE
MEN-4923: do not use upsert when acquiring jobs

### DIFF
--- a/app/worker/process.go
+++ b/app/worker/process.go
@@ -49,11 +49,7 @@ func processJob(ctx context.Context, job *model.Job,
 		}
 		return nil
 	} else if acquiredJob == nil {
-		l.Warnf("The job with given ID (%s) does not exist", job.ID)
-		err := dataStore.UpdateJobStatus(ctx, job, model.StatusFailure)
-		if err != nil {
-			return err
-		}
+		l.Debugf("The job with given ID (%s) does not exist or was already taken", job.ID)
 		return nil
 	}
 	job = acquiredJob


### PR DESCRIPTION
When starting a workflow, we insert in the `jobs` collections first,
then in the `job_queue` one. For this reason, it doesn't make sense to
use upserts, as it will never happen the `jobs` collection won't contain
the job which is queued in the `job_queue` collection.

This commit should fix issues like:

```
Jul 20, 2021 @ 16:42:28.080 multiple write errors: [{write errors: [{E11000 duplicate key error collection: workflows.jobs index: _id_ dup key: { _id: \"60f6fcf4c3cceecd56968147\" }}]}, {<nil>}]
```

Changelog: title

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>