### PR TITLE
MEN-5083: HTML version in mime/alternative must be the last part

### DIFF
--- a/app/worker/smtp.go
+++ b/app/worker/smtp.go
@@ -83,13 +83,19 @@ func processSMTPTask(smtpTask *model.SMTPTask, job *model.Job,
 
 	altContent := &bytes.Buffer{}
 	altWriter := multipart.NewWriter(altContent)
-	if HTML != "" {
-		childContent, _ := altWriter.CreatePart(textproto.MIMEHeader{"Content-Type": {"text/html"}})
-		childContent.Write([]byte(HTML))
-	}
 	if body != "" {
-		childContent, _ := altWriter.CreatePart(textproto.MIMEHeader{"Content-Type": {"text/plain"}})
+		childContent, _ := altWriter.CreatePart(textproto.MIMEHeader{
+			"Content-Type":              {"text/plain; charset=utf-8"},
+			"Content-Transfer-Encoding": {"8bit"},
+		})
 		childContent.Write([]byte(body))
+	}
+	if HTML != "" {
+		childContent, _ := altWriter.CreatePart(textproto.MIMEHeader{
+			"Content-Type":              {"text/html; charset=utf-8"},
+			"Content-Transfer-Encoding": {"8bit"},
+		})
+		childContent.Write([]byte(HTML))
 	}
 	altWriter.Close()
 

--- a/app/worker/smtp_test.go
+++ b/app/worker/smtp_test.go
@@ -52,13 +52,15 @@ func TestProcessJobSMTP(t *testing.T) {
 				"Content-Type: multipart/alternative; boundary=ID\r\n" +
 				"\r\n" +
 				"--ID\r\n" +
-				"Content-Type: text/html\r\n" +
-				"\r\n" +
-				"<html><body>HTML</body></html>\r\n" +
-				"--ID\r\n" +
-				"Content-Type: text/plain\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n" +
+				"Content-Type: text/plain; charset=utf-8\r\n" +
 				"\r\n" +
 				"Body\r\n" +
+				"--ID\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n" +
+				"Content-Type: text/html; charset=utf-8\r\n" +
+				"\r\n" +
+				"<html><body>HTML</body></html>\r\n" +
 				"--ID--\r\n",
 		},
 		"text only": {
@@ -72,7 +74,8 @@ func TestProcessJobSMTP(t *testing.T) {
 				"Content-Type: multipart/alternative; boundary=ID\r\n" +
 				"\r\n" +
 				"--ID\r\n" +
-				"Content-Type: text/plain\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n" +
+				"Content-Type: text/plain; charset=utf-8\r\n" +
 				"\r\n" +
 				"Body\r\n" +
 				"--ID--\r\n",
@@ -88,7 +91,8 @@ func TestProcessJobSMTP(t *testing.T) {
 				"Content-Type: multipart/alternative; boundary=ID\r\n" +
 				"\r\n" +
 				"--ID\r\n" +
-				"Content-Type: text/html\r\n" +
+				"Content-Transfer-Encoding: 8bit\r\n" +
+				"Content-Type: text/html; charset=utf-8\r\n" +
 				"\r\n" +
 				"<html><body>HTML</body></html>\r\n" +
 				"--ID--\r\n",


### PR DESCRIPTION
GMail doesn't display the HTML version of the message if it appears in
the first part of the mime/alternative. Move it to the last part to make
it display correctly. At the same time, improve the MIME headers setting
the charset to "UTF-8".

Changelog: none

Signed-off-by: Fabio Tranchitella <fabio.tranchitella@northern.tech>