### PR TITLE
[MEN-5153] Integrate azure-iot-manager with provision/decomission and submit configuration

### DIFF
--- a/Dockerfile.acceptance-testing.worker
+++ b/Dockerfile.acceptance-testing.worker
@@ -18,6 +18,7 @@ COPY ./worker/config.yaml /etc/workflows/config.yaml
 COPY ./worker/decommission_device.json .
 COPY ./worker/deploy_device_configuration.json .
 COPY ./worker/provision_device.json .
+COPY ./worker/submit_device_configuration.json .
 COPY ./worker/update_device_status.json .
 COPY ./worker/update_device_inventory.json .
 COPY ./worker/reindex_reporting.json .

--- a/Dockerfile.worker
+++ b/Dockerfile.worker
@@ -17,6 +17,7 @@ COPY ./worker/config.yaml /etc/workflows/config.yaml
 COPY ./worker/decommission_device.json .
 COPY ./worker/deploy_device_configuration.json .
 COPY ./worker/provision_device.json .
+COPY ./worker/submit_device_configuration.json .
 COPY ./worker/update_device_status.json .
 COPY ./worker/update_device_inventory.json .
 COPY ./worker/reindex_reporting.json .

--- a/Makefile
+++ b/Makefile
@@ -48,11 +48,11 @@ clean:
 
 .PHONY: acceptance-testing-up
 acceptance-testing-up:
-	docker-compose $(COMPOSEFILES_ACCEPTANCE_TESTING) up -d
+	docker-compose $(COMPOSEFILES_ACCEPTANCE_TESTING) up --scale acceptance-testing=0 -d
 
 .PHONY: acceptance-testing-run
 acceptance-testing-run:
-	docker exec tests_acceptance-testing_1 /testing/run.sh
+	docker-compose $(COMPOSEFILES_ACCEPTANCE_TESTING) run --rm acceptance-testing
 
 .PHONY: acceptance-testing-logs
 acceptance-testing-logs:

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -17,6 +17,7 @@ services:
           - mender-deviceconnect
           - mender-deviceconfig
           - mender-reporting
+          - mender-azure-iot-manager
           - mmock
 
   workflows-worker:

--- a/tests/docker-compose.acceptance.yml
+++ b/tests/docker-compose.acceptance.yml
@@ -27,8 +27,7 @@ services:
 
   acceptance-testing:
     image: mendersoftware/mender-test-containers:acceptance-testing
-    entrypoint: sh
-    command: -c "while true; do sleep 5; done;"
+    entrypoint: /testing/run.sh
     volumes:
       - ".:/testing"
     networks:

--- a/tests/mmock/azure-iot-manager_POST_devices.json
+++ b/tests/mmock/azure-iot-manager_POST_devices.json
@@ -1,0 +1,10 @@
+{
+    "description": "azure-iot-manager: provision device",
+    "request": {
+        "method": "POST",
+        "path": "/api/internal/v1/azure-iot-manager/tenants//devices"
+    },
+    "response": {
+        "statusCode": 201
+    }
+}

--- a/tests/mmock/azure-iot-manager_POST_devices_with_tenant_id.json
+++ b/tests/mmock/azure-iot-manager_POST_devices_with_tenant_id.json
@@ -1,0 +1,10 @@
+{
+    "description": "azure-iot-manager: provision device",
+    "request": {
+        "method": "POST",
+        "path": "/api/internal/v1/azure-iot-manager/tenants/123456789012345678901234/devices"
+    },
+    "response": {
+        "statusCode": 201
+    }
+}

--- a/worker/decommission_device.json
+++ b/worker/decommission_device.json
@@ -1,7 +1,7 @@
 {
     "name": "decommission_device",
     "description": "Removes device info from all services.",
-    "version": 6,
+    "version": 7,
     "tasks": [
         {
             "name": "delete_device_inventory",
@@ -65,6 +65,25 @@
                 "connectionTimeOut": 8000,
                 "readTimeOut": 8000,
                 "statusCodes": [204, 404]
+            }
+        },
+        {
+            "name": "delete_azure_iot_device",
+            "type": "http",
+            "retries": 3,
+            "http": {
+                "uri": "http://${env.AZURE_IOT_MANAGER_ADDR|mender-azure-iot-manager:8080}/api/internal/v1/azure-iot-manager/tenants/${workflow.input.tenant_id}/devices/${workflow.input.device_id}",
+                "method": "DELETE",
+                "headers": {
+                    "X-MEN-RequestID": "${workflow.input.request_id}"
+                },
+                "connectionTimeOut": 8000,
+                "readTimeOut": 8000,
+                "statusCodes": [
+                    202,
+                    204,
+                    404
+                ]
             }
         }
     ],

--- a/worker/provision_device.json
+++ b/worker/provision_device.json
@@ -1,7 +1,7 @@
 {
     "name": "provision_device",
     "description": "Provision device.",
-    "version": 6,
+    "version": 7,
     "tasks": [
         {
             "name": "create_device_inventory",
@@ -56,6 +56,30 @@
                 "connectionTimeOut": 8000,
                 "readTimeOut": 8000,
                 "statusCodes": [201, 409]
+            }
+        },
+        {
+            "name": "provision_azure-iot-manager",
+            "type": "http",
+            "retries": 3,
+            "http": {
+                "uri": "http://${env.AZURE_IOT_MANAGER_ADDR|mender-azure-iot-manager:8080}/api/internal/v1/azure-iot-manager/tenants/${workflow.input.tenant_id}/devices",
+                "method": "POST",
+                "contentType": "application/json",
+                "json": {
+                    "device_id": "${workflow.input.device_id}"
+                },
+                "headers": {
+                    "X-MEN-RequestID": "${workflow.input.request_id}"
+                },
+                "connectionTimeOut": 8000,
+                "readTimeOut": 8000,
+                "statusCodes": [
+                    201,
+                    202,
+                    204,
+                    409
+                ]
             }
         }
     ],

--- a/worker/submit_device_configuration.json
+++ b/worker/submit_device_configuration.json
@@ -1,0 +1,32 @@
+{
+    "name": "submit_configuration",
+    "description": "Submit device configuration settings",
+    "ephemeral": true,
+    "version": 1,
+    "tasks": [
+        {
+            "name": "submit_configuration",
+            "type": "http",
+            "retries": 3,
+            "http": {
+                "requires": ["${env.HAVE_DEVICECONFIG}"],
+                "uri": "http://${env.DEVICECONFIG_ADDR|mender-deviceconfig:8080}/api/internal/v1/deviceconfig/tenants/${workflow.input.tenant_id}/configurations/device/${workflow.input.device_id}",
+                "method": "PATCH",
+                "headers": {
+                    "X-MEN-Requestid": "${workflow.input.request_id}",
+                    "Content-Type": "application/json"
+                },
+                "json": "${workflow.input.configuration}",
+                "connectionTimeOut": 8000,
+                "readTimeOut": 8000,
+                "statusCodes": [200, 204, 404]
+            }
+        }
+    ],
+    "inputParameters": [
+        "request_id",
+        "tenant_id",
+        "device_id",
+        "configuration"
+    ]
+}


### PR DESCRIPTION
New workflow submit_configuration calling the `PATCH /configuration` endpoint in mendersoftware/deviceconfig#85 as part of mendersoftware/azure-iot-manager#9.