### PR TITLE
ci: Replace Coveralls with Codecov

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -144,26 +144,15 @@ publish:acceptance:
   dependencies:
     - test:acceptance_tests
   before_script:
-    - apk add --no-cache git
-    # Coveralls env variables:
-    #  According to https://docs.coveralls.io/supported-ci-services
-    #  we should set CI_NAME, CI_BUILD_NUMBER, etc. But according
-    #  to goveralls source code (https://github.com/mattn/goveralls)
-    #  many of these are not supported. Set CI_BRANCH, CI_PR_NUMBER,
-    #  and pass few others as command line arguments.
-    #  See also https://docs.coveralls.io/api-reference
-    - export CI_BRANCH=${CI_COMMIT_BRANCH}
-    - export CI_PR_NUMBER=${CI_COMMIT_BRANCH#pr_}
-    - go install github.com/mattn/goveralls@latest
-    # Convert coverage directory to text format
     - go tool covdata textfmt -i tests/coverage -o coverage.txt
   script:
-    - |-
-      goveralls \
-      -repotoken ${COVERALLS_TOKEN} \
-      -service gitlab-ci \
-      -jobid $CI_PIPELINE_ID \
-      -covermode set \
-      -flagname acceptance \
-      -parallel \
-      -coverprofile coverage.txt
+    - wget -q https://cli.codecov.io/latest/alpine/codecov
+    - chmod +x codecov
+    - ./codecov upload-process
+      --fail-on-error
+      --git-service github
+      --slug mendersoftware/${CI_PROJECT_NAME}
+      --sha ${CI_COMMIT_SHA}
+      --pr $(echo "${CI_COMMIT_BRANCH}" | sed 's/^pr_//')
+      --file coverage.txt
+      --flag acceptance


### PR DESCRIPTION
## Summary
- Replace goveralls/Coveralls with Codecov CLI (`cli.codecov.io`) for coverage reporting
- Keep `golang:1.22.2-alpine3.19` image (needed for `go tool covdata textfmt` binary→text conversion)
- Use `wget` to download alpine Codecov binary
- Ticket: QA-1574